### PR TITLE
Fix todo item completion property

### DIFF
--- a/src/Playground.Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommand.cs
+++ b/src/Playground.Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommand.cs
@@ -12,7 +12,7 @@ namespace Playground.Application.Features.ToDoItems.Command.Create.Models
         public string Task { get; set; } = string.Empty;
 
         [JsonPropertyName("is_completed")]
-        public bool IsCompleted = false;
+        public bool IsCompleted { get; set; } = false;
 
         public override IEnumerable<string> ErrosList()
         {


### PR DESCRIPTION
## Summary
- change `IsCompleted` from field to property in `CreateToDoItemCommand`

## Testing
- `dotnet build src/Playground.Ecs.sln --no-restore` *(fails: CS8603 possible null reference return)*

------
https://chatgpt.com/codex/tasks/task_e_684342c7555c832cab8a3801cdbd3ba1