### PR TITLE
Fix variable typo

### DIFF
--- a/src/Playground.Application/Infrastructure/Extensions/LogDebugWithCorrelationCheck.cs
+++ b/src/Playground.Application/Infrastructure/Extensions/LogDebugWithCorrelationCheck.cs
@@ -7,10 +7,10 @@ namespace Playground.Application.Infrastructure.Extensions
     {
         public static void LogTroubleshooting(this ILogger logger, string message)
         {
-            Guid correlationIdToDebud = new("550e8400-1234-5678-9999-999900000001"); //TODO: Take from FeatureManager
+            Guid correlationIdToDebug = new("550e8400-1234-5678-9999-999900000001"); //TODO: Take from FeatureManager
             var correlationId = CorrelationContext.GetCorrelationId();
 
-            if (correlationId == correlationIdToDebud)
+            if (correlationId == correlationIdToDebug)
             {
                 logger.LogInformation(message);
             }


### PR DESCRIPTION
## Summary
- fix the variable name `correlationIdToDebud` -> `correlationIdToDebug`

## Testing
- `dotnet test src/Playground.Ecs.sln -nologo` *(fails: error CS8603 Possible null reference return)*

------
https://chatgpt.com/codex/tasks/task_e_684342bb7c0c832ca1f591f1b5d2577c