### PR TITLE
Fix CreateToDoItemControllerTest expected output

### DIFF
--- a/src/Playground.Tests/Api/Controller/ToDoItemController/CreateToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/CreateToDoItemControllerTest.cs
@@ -43,7 +43,7 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<CreatedAtRouteResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status201Created, response.StatusCode);
-            Assert.Null(response.Value);
+            Assert.Equal(_validOutput, response.Value);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- update CreateAsync valid input test to assert created output object

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684372590218832caf140bd0a126b6ca