### PR TITLE
Update workflow to compile project

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
+    - name: Build ArquivosDoDisco.Web
+      run: dotnet build ./ArquivosDoDisco.Web/ArquivosDoDisco.Web.csproj --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to build `ArquivosDoDisco.Web`

## Testing
- `dotnet restore src/Playground.Ecs.sln` *(fails: The current .NET SDK does not support targeting .NET 8.0)*
- `dotnet test src/Playground.Ecs.sln --no-build --verbosity normal` *(fails: VSTest task returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9b71170832ca0ac840a04fb6297