### PR TITLE
Refactor PokemonApi exception handling

### DIFF
--- a/src/Playground.Application/Shared/ExternalServices/PokemonApi.cs
+++ b/src/Playground.Application/Shared/ExternalServices/PokemonApi.cs
@@ -65,27 +65,15 @@ namespace Playground.Application.Shared.ExternalServices
                 }
                 catch (TaskCanceledException exception)
                 {
-                    _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro de Timeout. input:({name})");
-
-                    throw;
+                    HandleTaskCanceledException(exception, name);
                 }
-                catch (ApiException exception) when
-                    (exception.StatusCode is HttpStatusCode.NoContent)
+                catch (ApiException exception)
                 {
-                    _logger.LogWarning($"[PokemonApi][GetByNameAsync] Nenhum dado retornou da API. input:({name})");
-                }
-                catch (ApiException exception) when
-                    (exception.StatusCode is HttpStatusCode.InternalServerError)
-                {
-                    _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro de integração. Erro: {exception.InnerException}. input:({name})");
-
-                    throw;
+                    HandleApiException(exception, name);
                 }
                 catch (Exception exception)
                 {
-                    _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro desconhecido input:({name})");
-
-                    throw;
+                    HandleGenericException(exception, name);
                 }
                 finally
                 {
@@ -100,5 +88,37 @@ namespace Playground.Application.Shared.ExternalServices
                 return attemptResult ?? new();
             }) ?? new();
         }
+
+        private void HandleTaskCanceledException(TaskCanceledException exception, string name)
+        {
+            _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro de Timeout. input:({name})");
+
+            throw exception;
+        }
+
+        private void HandleApiException(ApiException exception, string name)
+        {
+            if (exception.StatusCode == HttpStatusCode.NoContent)
+            {
+                _logger.LogWarning($"[PokemonApi][GetByNameAsync] Nenhum dado retornou da API. input:({name})");
+                return;
+            }
+
+            if (exception.StatusCode == HttpStatusCode.InternalServerError)
+            {
+                _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro de integração. Erro: {exception.InnerException}. input:({name})");
+                throw exception;
+            }
+
+            _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro de integração. StatusCode: {exception.StatusCode}. input:({name})");
+            throw exception;
+        }
+
+        private void HandleGenericException(Exception exception, string name)
+        {
+            _logger.LogError(exception, $"[PokemonApi][GetByNameAsync] Erro desconhecido input:({name})");
+            throw exception;
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- centralize exception logging for `PokemonApi.GetByNameAsync`
- use `HandleTaskCanceledException`, `HandleApiException`, and `HandleGenericException`

## Testing
- `dotnet test src/Playground.Tests/Playground.Tests.csproj -c Release --no-build` *(fails: The type or namespace name 'Command' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684739e2e764832c9285cfc83a97b8b2