### PR TITLE
Enable Dapper.AOT mapping

### DIFF
--- a/src/Playground.Application/DapperAotModule.cs
+++ b/src/Playground.Application/DapperAotModule.cs
@@ -1,0 +1,3 @@
+using Dapper;
+
+[module:DapperAot]

--- a/src/Playground.Application/Features/Country/Query/GetAll/Repositories/GetAllCountryRepository.cs
+++ b/src/Playground.Application/Features/Country/Query/GetAll/Repositories/GetAllCountryRepository.cs
@@ -11,6 +11,11 @@ namespace Playground.Application.Features.Country.Query.GetAll.Repositories
 {
     public class GetAllCountryRepository : IGetAllCountryRepository
     {
+        static GetAllCountryRepository()
+        {
+            DefaultTypeMap.MatchNamesWithUnderscores = true;
+        }
+
         private readonly IDbConnection _connection;
         private readonly IMemoryCache _memoryCache;
         private readonly ILogger<GetAllCountryRepository> _logger;

--- a/src/Playground.Application/Features/Country/Query/GetByName/Repositories/GetByNameCountryRepository.cs
+++ b/src/Playground.Application/Features/Country/Query/GetByName/Repositories/GetByNameCountryRepository.cs
@@ -8,6 +8,11 @@ namespace Playground.Application.Features.Country.Query.GetByName.Repositories
 {
     public class GetByNameCountryRepository : IGetByNameCountryRepository
     {
+        static GetByNameCountryRepository()
+        {
+            DefaultTypeMap.MatchNamesWithUnderscores = true;
+        }
+
         private readonly IDbConnection _connection;
 
         public GetByNameCountryRepository(IDbConnection connection)

--- a/src/Playground.Application/Features/ToDoItems/Command/Create/Repositories/CreateTodoItemRepository.cs
+++ b/src/Playground.Application/Features/ToDoItems/Command/Create/Repositories/CreateTodoItemRepository.cs
@@ -8,6 +8,11 @@ namespace Playground.Application.Features.ToDoItems.Command.Create.Repositories
 {
     public class CreateTodoItemRepository : ICreateTodoItemRepository
     {
+        static CreateTodoItemRepository()
+        {
+            DefaultTypeMap.MatchNamesWithUnderscores = true;
+        }
+
         private readonly IDbConnection _connection;
 
         public CreateTodoItemRepository(IDbConnection connection)
@@ -17,13 +22,11 @@ namespace Playground.Application.Features.ToDoItems.Command.Create.Repositories
 
         public async Task<CreateToDoItemOutput> CreateToDoItemAsync(CreateToDoItemCommand input, CancellationToken cancellationToken)
         {
-            return new() { Id = 1 };
-
-            //return await _connection.QueryFirstOrDefaultAsync<CreateToDoItemOutput>(new CommandDefinition(
-            //    commandText: CreateTodoItemRepositoryScript.SqlScript,
-            //    cancellationToken: cancellationToken,
-            //    commandTimeout: 1
-            //));
+            return await _connection.QueryFirstOrDefaultAsync<CreateToDoItemOutput>(new CommandDefinition(
+                commandText: CreateTodoItemRepositoryScript.SqlScript,
+                cancellationToken: cancellationToken,
+                commandTimeout: 1
+            )) ?? new CreateToDoItemOutput();
         }
     }
 }

--- a/src/Playground.Application/Playground.Application.csproj
+++ b/src/Playground.Application/Playground.Application.csproj
@@ -8,6 +8,10 @@
     <RefitGenerateStubs>true</RefitGenerateStubs>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Dapper.AOT</InterceptorsPreviewNamespaces>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="Features\ToDoItems\Command\PatchIsCompleted\Entities\" />
     <Folder Include="Features\ToDoItems\Command\PatchIsCompleted\Interface\" />
@@ -35,6 +39,7 @@
     <PackageReference Include="Autofac" Version="8.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Castle.Core" Version="5.2.1" />
+    <PackageReference Include="Dapper.AOT" Version="1.0.48" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Flunt" Version="2.0.5" />
     <PackageReference Include="MediatR" Version="12.5.0" />


### PR DESCRIPTION
## Summary
- opt in to Dapper.AOT interceptors
- enable mapping underscores in repositories
- use actual Dapper call in create repository

## Testing
- `dotnet restore src/Playground.Ecs.sln`
- `dotnet build src/Playground.Ecs.sln --no-restore`
- `dotnet test src/Playground.Ecs.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684785e21f54832ca2ce818182a50a3b