### PR TITLE
Enable Native AOT build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,3 +26,5 @@ jobs:
       run: dotnet build src/Playground.Ecs.sln --no-restore
     - name: Test
       run: dotnet test src/Playground.Ecs.sln --no-build --verbosity normal
+    - name: Publish AOT
+      run: dotnet publish src/Playground.ControllerApi/Playground.csproj -c Release -r linux-x64 /p:PublishAot=true

--- a/src/Playground.ControllerApi/CustomInitializers/RegisterCustomServicesInitializer.cs
+++ b/src/Playground.ControllerApi/CustomInitializers/RegisterCustomServicesInitializer.cs
@@ -55,10 +55,8 @@ namespace Microsoft.AspNetCore.Builder
 
         public static void ConfigureMediatR(IServiceCollection services)
         {
-            services.AddMediatR(cfg =>
-            {
-                cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
-            });
+            // Configure MediatR without assembly scanning to avoid reflection
+            services.AddMediatR(cfg => { });
 
             services.AddRequestHandlers();
         }

--- a/src/Playground.ControllerApi/Playground.csproj
+++ b/src/Playground.ControllerApi/Playground.csproj
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove reflection-based MediatR registration
- enable PublishAot and trimming for controller project
- publish native binary in CI workflow
- fix unit tests by initializing MediatR without scanning

## Testing
- `dotnet test src/Playground.Ecs.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6847619fdcc8832cbb2f981aab3264d9