### PR TITLE
Add coverage report step

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,6 +25,11 @@ jobs:
     - name: Build
       run: dotnet build src/Playground.Ecs.sln --no-restore
     - name: Test
-      run: dotnet test src/Playground.Ecs.sln --no-build --verbosity normal
+      run: dotnet test src/Playground.Ecs.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
+    - name: Generate coverage report
+      run: |
+        dotnet tool install --global dotnet-reportgenerator-globaltool
+        reportgenerator -reports:**/coverage.cobertura.xml -targetdir:coveragereport -reporttypes:TextSummary
+        cat coveragereport/Summary.txt
     - name: Publish AOT
       run: dotnet publish src/Playground.ControllerApi/Playground.csproj -c Release -r linux-x64 /p:PublishAot=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Este documento descreve como escrever e organizar testes unitários neste projet
   - Controller `CountryController` -> testes em `src/Playground.Tests/Api/Controller/CountryController/`.
   - Cada ação do controller possui seu próprio arquivo de teste com o nome `<NomeDaAcao><Controller>Test.cs`.
 - O namespace de todas as classes de teste é `Playground.Tests.Controllers`.
+- Sempre que criar uma nova pasta de testes, replique exatamente o nome do controller para facilitar a localização dos arquivos.
+- Utilize a pasta `Template` como ponto de partida para novas classes.
 
 ## Orientações para as classes de teste
 
@@ -19,8 +21,12 @@ Este documento descreve como escrever e organizar testes unitários neste projet
   - Os nomes dos métodos seguem o formato `Metodo_QuandoCondicao_DeveRetornarResultado`.
   - Verifique o tipo exato do `IActionResult` retornado (`OkObjectResult`, `BadRequestObjectResult`, etc.) e os valores de `StatusCode` e `Value`.
 - Utilize **Moq** para simular dependências.
+- Quando necessário, utilize `Verify` nos mocks para garantir que métodos foram executados.
+- Empregue `CancellationToken.None` nas chamadas do controlador para simplificar os testes.
+- Mantenha cada arquivo com apenas uma classe de teste para facilitar a manutenção.
 - Consulte `src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs` para um exemplo de estrutura (o arquivo está envolto em `#if false` para não ser compilado).
 
 ## Requisitos de workflow
 
 Sempre que modificar ou criar testes, execute `dotnet build` e `dotnet test` no `src/Playground.Ecs.sln` para garantir que o projeto compila e que os testes passam.
+No CI do repositório a cobertura de código é calculada automaticamente e o resumo pode ser conferido no arquivo `coveragereport/Summary.txt` gerado pelo passo `reportgenerator`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,26 @@
-# AGENT instructions for Playground.Ecs repository
+# Instruções do AGENT para o repositório Playground.Ecs
 
-This file documents the conventions for writing unit tests in this project.
+Este documento descreve como escrever e organizar testes unitários neste projeto.
 
-## Test directory layout
+## Estrutura de diretórios
 
-- All unit tests live under `src/Playground.Tests`.
-- Inside that folder the structure mirrors the API controllers. For example:
-  - Controller `CountryController` -> tests in `src/Playground.Tests/Api/Controller/CountryController/`.
-  - Each controller action has its own test file named `<ActionName><Controller>Test.cs`.
-- The namespace for all test classes is `Playground.Tests.Controllers`.
+- Todos os testes unitários ficam em `src/Playground.Tests`.
+- Dentro dessa pasta a organização reproduz os controllers da API. Por exemplo:
+  - Controller `CountryController` -> testes em `src/Playground.Tests/Api/Controller/CountryController/`.
+  - Cada ação do controller possui seu próprio arquivo de teste com o nome `<NomeDaAcao><Controller>Test.cs`.
+- O namespace de todas as classes de teste é `Playground.Tests.Controllers`.
 
-## Test class guidelines
+## Orientações para as classes de teste
 
-- Use **xUnit** and place `global using Xunit;` in `src/Playground.Tests/Usings.cs`.
-- Declare private fields for all mocks (`Mock<IMediator>`, `Mock<ILogger<T>>`, etc.) and the controller being tested.
-- Initialize mocks and controller instances in the constructor of the test class.
-- Follow the Arrange / Act / Assert pattern inside each `[Fact]` method.
-  - Method names use Portuguese phrases such as `Metodo_QuandoCondicao_DeveRetornarResultado`.
-  - Verify the specific `IActionResult` type (`OkObjectResult`, `BadRequestObjectResult`, etc.) and its `StatusCode`/`Value`.
-- Use **Moq** for mocking dependencies.
-- See `src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs` for a sample layout (wrapped in `#if false` so it does not compile).
+- Utilize **xUnit** e coloque `global using Xunit;` em `src/Playground.Tests/Usings.cs`.
+- Declare campos privados para todos os mocks (`Mock<IMediator>`, `Mock<ILogger<T>>`, etc.) e para o controller testado.
+- Inicialize os mocks e o controller no construtor da classe de teste.
+- Siga o padrão **Arrange / Act / Assert** em cada método decorado com `[Fact]`.
+  - Os nomes dos métodos seguem o formato `Metodo_QuandoCondicao_DeveRetornarResultado`.
+  - Verifique o tipo exato do `IActionResult` retornado (`OkObjectResult`, `BadRequestObjectResult`, etc.) e os valores de `StatusCode` e `Value`.
+- Utilize **Moq** para simular dependências.
+- Consulte `src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs` para um exemplo de estrutura (o arquivo está envolto em `#if false` para não ser compilado).
 
-## Workflow requirements
+## Requisitos de workflow
 
-Whenever modifying or adding tests, run `dotnet build` and `dotnet test` on `src/Playground.Ecs.sln` to ensure the project compiles and tests pass.
+Sempre que modificar ou criar testes, execute `dotnet build` e `dotnet test` no `src/Playground.Ecs.sln` para garantir que o projeto compila e que os testes passam.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENT instructions for Playground.Ecs repository
+
+This file documents the conventions for writing unit tests in this project.
+
+## Test directory layout
+
+- All unit tests live under `src/Playground.Tests`.
+- Inside that folder the structure mirrors the API controllers. For example:
+  - Controller `CountryController` -> tests in `src/Playground.Tests/Api/Controller/CountryController/`.
+  - Each controller action has its own test file named `<ActionName><Controller>Test.cs`.
+- The namespace for all test classes is `Playground.Tests.Controllers`.
+
+## Test class guidelines
+
+- Use **xUnit** and place `global using Xunit;` in `src/Playground.Tests/Usings.cs`.
+- Declare private fields for all mocks (`Mock<IMediator>`, `Mock<ILogger<T>>`, etc.) and the controller being tested.
+- Initialize mocks and controller instances in the constructor of the test class.
+- Follow the Arrange / Act / Assert pattern inside each `[Fact]` method.
+  - Method names use Portuguese phrases such as `Metodo_QuandoCondicao_DeveRetornarResultado`.
+  - Verify the specific `IActionResult` type (`OkObjectResult`, `BadRequestObjectResult`, etc.) and its `StatusCode`/`Value`.
+- Use **Moq** for mocking dependencies.
+- See `src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs` for a sample layout (wrapped in `#if false` so it does not compile).
+
+## Workflow requirements
+
+Whenever modifying or adding tests, run `dotnet build` and `dotnet test` on `src/Playground.Ecs.sln` to ensure the project compiles and tests pass.

--- a/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Playground.Controllers;
+
+namespace Playground.Tests.Controllers
+{
+    public class GenerateTokenAuthControllerTest
+    {
+        private readonly Mock<ILogger<AuthController>> _mockLogger;
+        private readonly AuthController _controller;
+
+        public GenerateTokenAuthControllerTest()
+        {
+            _mockLogger = new Mock<ILogger<AuthController>>();
+            _controller = new AuthController(_mockLogger.Object);
+        }
+
+        [Fact]
+        public void GenerateToken_DeveRetornarOkComToken()
+        {
+            var user = new AuthController.AuthUser("1", "tester", "group");
+
+            var actionResult = _controller.GenerateToken(user);
+
+            var response = Assert.IsType<OkObjectResult>(actionResult);
+            dynamic value = response.Value!;
+            Assert.NotNull(value.Token);
+            Assert.NotEqual(string.Empty, value.Token.ToString());
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
@@ -24,9 +24,12 @@ namespace Playground.Tests.Controllers
             var actionResult = _controller.GenerateToken(user);
 
             var response = Assert.IsType<OkObjectResult>(actionResult);
-            dynamic value = response.Value!;
-            Assert.NotNull(value.Token);
-            Assert.NotEqual(string.Empty, value.Token.ToString());
+
+            Assert.NotNull(response.Value);
+            var tokenProperty = response.Value!.GetType().GetProperty("Token");
+            Assert.NotNull(tokenProperty);
+            var token = tokenProperty!.GetValue(response.Value) as string;
+            Assert.False(string.IsNullOrEmpty(token));
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/AuthController/GenerateTokenAuthControllerTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Playground.Controllers;
 
 namespace Playground.Tests.Controllers

--- a/src/Playground.Tests/Api/Controller/CountryController/GetAllCountryControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/CountryController/GetAllCountryControllerTest.cs
@@ -39,6 +39,9 @@ namespace Playground.Tests.Controllers
             var responseData = Assert.IsType<List<GetAllCountryOutput>>(response.Value);
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.Equal(output, responseData);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetAllCountryQuery>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -54,6 +57,9 @@ namespace Playground.Tests.Controllers
 
             var response = Assert.IsType<NoContentResult>(result);
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetAllCountryQuery>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/CountryController/GetAllCountryControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/CountryController/GetAllCountryControllerTest.cs
@@ -1,0 +1,59 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers;
+using Playground.Application.Features.Country.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllCountryControllerTest
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<CountryController>> _mockLogger;
+        private readonly CountryController _controller;
+
+        public GetAllCountryControllerTest()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<CountryController>>();
+            _controller = new CountryController(_mockMediator.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_QuandoExistemPaises_DeveRetornarOk()
+        {
+            var output = new List<GetAllCountryOutput>
+            {
+                new GetAllCountryOutput { Name = "Brazil" }
+            };
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<GetAllCountryQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(output);
+
+            var result = await _controller.GetAllAsync(CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(result);
+            var responseData = Assert.IsType<List<GetAllCountryOutput>>(response.Value);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(output, responseData);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_QuandoNaoExistemPaises_DeveRetornarNoContent()
+        {
+            var output = new List<GetAllCountryOutput>();
+
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<GetAllCountryQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(output);
+
+            var result = await _controller.GetAllAsync(CancellationToken.None);
+
+            var response = Assert.IsType<NoContentResult>(result);
+            Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/CountryController/GetByNameCountryControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/CountryController/GetByNameCountryControllerTest.cs
@@ -1,0 +1,78 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers;
+using Playground.Application.Features.Country.Query.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameCountryControllerTest
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<CountryController>> _mockLogger;
+        private readonly CountryController _controller;
+        private readonly GetByNameCountryQuery _validInput;
+        private readonly GetByNameCountryQuery _invalidInput;
+        private readonly GetByNameCountryOutput _validOutput;
+        private readonly GetByNameCountryOutput _invalidOutput;
+
+        public GetByNameCountryControllerTest()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<CountryController>>();
+            _controller = new CountryController(_mockMediator.Object, _mockLogger.Object);
+
+            _validInput = new GetByNameCountryQuery();
+            _validInput.SetName("brazil");
+
+            _invalidInput = new GetByNameCountryQuery();
+            _invalidInput.SetName(string.Empty);
+
+            _validOutput = new GetByNameCountryOutput { Name = "Brazil" };
+            _invalidOutput = new GetByNameCountryOutput { Name = string.Empty };
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_QuandoEntradaValida_DeveRetornarOk()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_validOutput);
+
+            var result = await _controller.GetByNameAsync(_validInput.Name, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(_validOutput, response.Value);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_QuandoEntradaInvalida_DeveRetornarBadRequest()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_invalidInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByNameAsync(_invalidInput.Name, _invalidInput, CancellationToken.None);
+
+            var response = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+            Assert.NotNull(response.Value);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_QuandoOutputInvalido_DeveRetornarNoContent()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByNameAsync(_validInput.Name, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<NoContentResult>(result);
+            Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/CountryController/GetByNameCountryControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/CountryController/GetByNameCountryControllerTest.cs
@@ -46,6 +46,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.Equal(_validOutput, response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -60,6 +63,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetByNameCountryQuery>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -73,6 +79,9 @@ namespace Playground.Tests.Controllers
 
             var response = Assert.IsType<NoContentResult>(result);
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/PokemonController/GetByNameExternalPokemonControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/PokemonController/GetByNameExternalPokemonControllerTest.cs
@@ -52,6 +52,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.Equal(_validOutput, response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -66,6 +69,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetByNamePokemonQuery>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -79,6 +85,9 @@ namespace Playground.Tests.Controllers
 
             var response = Assert.IsType<NoContentResult>(result);
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/PokemonController/GetByNameExternalPokemonControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/PokemonController/GetByNameExternalPokemonControllerTest.cs
@@ -1,0 +1,84 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers;
+using Playground.Application.Features.Pokemon.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameExternalPokemonControllerTest
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<PokemonController>> _mockLogger;
+        private readonly PokemonController _controller;
+        private readonly GetByNamePokemonQuery _validInput;
+        private readonly GetByNamePokemonQuery _invalidInput;
+        private readonly GetByNamePokemonOutput _validOutput;
+        private readonly GetByNamePokemonOutput _invalidOutput;
+
+        public GetByNameExternalPokemonControllerTest()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<PokemonController>>();
+            _controller = new PokemonController(_mockMediator.Object, _mockLogger.Object);
+
+            _validInput = new GetByNamePokemonQuery();
+            _validInput.SetName("pikachu");
+
+            _invalidInput = new GetByNamePokemonQuery();
+            _invalidInput.SetName(string.Empty);
+
+            _validOutput = new GetByNamePokemonOutput
+            {
+                Name = "pikachu",
+                BaseExperience = 100,
+                LocationAreaEncounters = "Forest"
+            };
+
+            _invalidOutput = new GetByNamePokemonOutput();
+        }
+
+        [Fact]
+        public async Task GetByNameExternalAsync_QuandoValido_DeveRetornarOk()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_validOutput);
+
+            var result = await _controller.GetByNameExternalAsync(_validInput.Name, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(_validOutput, response.Value);
+        }
+
+        [Fact]
+        public async Task GetByNameExternalAsync_QuandoEntradaInvalida_DeveRetornarBadRequest()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_invalidInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByNameExternalAsync(_invalidInput.Name, _invalidInput, CancellationToken.None);
+
+            var response = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+            Assert.NotNull(response.Value);
+        }
+
+        [Fact]
+        public async Task GetByNameExternalAsync_QuandoOutputInvalido_DeveRetornarNoContent()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByNameExternalAsync(_validInput.Name, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<NoContentResult>(result);
+            Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/PokemonController/GetByNameInternalPokemonControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/PokemonController/GetByNameInternalPokemonControllerTest.cs
@@ -1,0 +1,42 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers;
+using Playground.Application.Shared.Domain.ApiDto;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameInternalPokemonControllerTest
+    {
+        private readonly Mock<ILogger<PokemonController>> _mockLogger;
+        private readonly PokemonController _controller;
+
+        public GetByNameInternalPokemonControllerTest()
+        {
+            _mockLogger = new Mock<ILogger<PokemonController>>();
+            _controller = new PokemonController(Mock.Of<IMediator>(), _mockLogger.Object);
+        }
+
+        [Fact]
+        public void GetByNameInternalAsync_QuandoPikachu_DeveRetornarOk()
+        {
+            var result = _controller.GetByNameInternalAsync("pikachu");
+
+            var response = Assert.IsType<OkObjectResult>(result);
+            var pokemon = Assert.IsType<PokemonOutApiDto>(response.Value);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal("pikachu", pokemon.Name);
+        }
+
+        [Fact]
+        public void GetByNameInternalAsync_QuandoNaoForPikachu_DeveRetornarNoContent()
+        {
+            var result = _controller.GetByNameInternalAsync("mew");
+
+            var response = Assert.IsType<NoContentResult>(result);
+            Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs
+++ b/src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs
@@ -1,0 +1,47 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers;
+
+namespace Playground.Tests.Controllers
+{
+    public class SampleControllerTestTemplate
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<SampleController>> _mockLogger;
+        private readonly SampleController _controller;
+
+        // private readonly SomeCommand _input;
+        // private readonly SomeOutput _output;
+
+        public SampleControllerTestTemplate()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<SampleController>>();
+
+            _controller = new SampleController(_mockMediator.Object, _mockLogger.Object);
+
+            // _input = new SomeCommand { ... };
+            // _output = new SomeOutput { ... };
+        }
+
+        [Fact]
+        public async Task Metodo_QuandoCondicao_DeveRetornarResultado()
+        {
+            var input = /* instanciar entrada */ default(SomeCommand);
+            var output = /* definir saída esperada */ default(SomeOutput);
+
+            _mockMediator
+                .Setup(mediator => mediator.Send(input, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(output);
+
+            var actionResult = await _controller.MetodoAsync(input, CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(actionResult);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(output, response.Value);
+        }
+    }
+}

--- a/src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs
+++ b/src/Playground.Tests/Api/Controller/Template/SampleControllerTestTemplate.cs
@@ -1,3 +1,4 @@
+#if false
 using Moq;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -45,3 +46,4 @@ namespace Playground.Tests.Controllers
         }
     }
 }
+#endif

--- a/src/Playground.Tests/Api/Controller/ToDoItemsController/GetByIdToDoItemsControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemsController/GetByIdToDoItemsControllerTest.cs
@@ -47,6 +47,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<OkObjectResult>(result);
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.Equal(_validOutput, response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -60,6 +63,9 @@ namespace Playground.Tests.Controllers
 
             var response = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetByIdToDoItemQuery>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -73,6 +79,9 @@ namespace Playground.Tests.Controllers
 
             var response = Assert.IsType<NoContentResult>(result);
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/ToDoItemsController/GetByIdToDoItemsControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemsController/GetByIdToDoItemsControllerTest.cs
@@ -1,0 +1,78 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Playground.Controllers.v2_0;
+using Playground.Controllers;
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByIdToDoItemsControllerTest
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<ToDoItemController>> _mockLogger;
+        private readonly ToDoItemsController _controller;
+        private readonly GetByIdToDoItemQuery _validInput;
+        private readonly GetByIdToDoItemQuery _invalidInput;
+        private readonly GetByIdToDoItemOutput _validOutput;
+        private readonly GetByIdToDoItemOutput _invalidOutput;
+
+        public GetByIdToDoItemsControllerTest()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<ToDoItemController>>();
+            _controller = new ToDoItemsController(_mockMediator.Object, _mockLogger.Object);
+
+            _validInput = new GetByIdToDoItemQuery();
+            _validInput.SetId(1);
+
+            _invalidInput = new GetByIdToDoItemQuery();
+            _invalidInput.SetId(0);
+
+            _validOutput = new GetByIdToDoItemOutput { Id = 1, Task = "Sample", IsCompleted = false };
+            _invalidOutput = new GetByIdToDoItemOutput { Id = 0, Task = string.Empty, IsCompleted = false };
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_QuandoValido_DeveRetornarOk()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_validOutput);
+
+            var result = await _controller.GetByIdAsync(_validInput.Id, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(_validOutput, response.Value);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_QuandoEntradaInvalida_DeveRetornarBadRequest()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_invalidInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByIdAsync(_invalidInput.Id, _invalidInput, CancellationToken.None);
+
+            var response = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_QuandoOutputInvalido_DeveRetornarNoContent()
+        {
+            _mockMediator
+                .Setup(m => m.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_invalidOutput);
+
+            var result = await _controller.GetByIdAsync(_validInput.Id, _validInput, CancellationToken.None);
+
+            var response = Assert.IsType<NoContentResult>(result);
+            Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- run tests with coverage enabled
- generate text coverage report in workflow

## Testing
- `dotnet test src/Playground.Ecs.sln --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847889101c4832cb4de71293daff502