### PR TITLE
Add Moq.Dapper and application tests

### DIFF
--- a/src/Playground.Tests/Application/Features/Country/Query/GetAll/Repositories/GetAllCountryRepositoryTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetAll/Repositories/GetAllCountryRepositoryTest.cs
@@ -1,0 +1,42 @@
+using Moq;
+using Moq.Dapper;
+using Dapper;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Playground.Application.Features.Country.Query.GetAll.Repositories;
+using Playground.Application.Features.Country.Query.GetAll.Models;
+using System.Data;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllCountryRepositoryTest
+    {
+        private readonly Mock<IDbConnection> _mockConnection;
+        private readonly IMemoryCache _memoryCache;
+        private readonly Mock<ILogger<GetAllCountryRepository>> _mockLogger;
+        private readonly GetAllCountryRepository _repository;
+
+        public GetAllCountryRepositoryTest()
+        {
+            _mockConnection = new Mock<IDbConnection>();
+            _memoryCache = new MemoryCache(new MemoryCacheOptions());
+            _mockLogger = new Mock<ILogger<GetAllCountryRepository>>();
+            _repository = new GetAllCountryRepository(_mockConnection.Object, _memoryCache, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task GetAllCountryAsync_DeveUtilizarCache()
+        {
+            var expected = new List<GetAllCountryOutput> { new GetAllCountryOutput { Name = "Brazil" } };
+            _mockConnection.SetupDapperAsync(c => c.QueryAsync<GetAllCountryOutput>(It.IsAny<CommandDefinition>()))
+                .ReturnsAsync(expected);
+
+            var first = await _repository.GetAllCountryAsync(CancellationToken.None);
+            var second = await _repository.GetAllCountryAsync(CancellationToken.None);
+
+            Assert.Single(first);
+            Assert.Equal("Brazil", first.First().Name);
+            Assert.Equal(first, second);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetAll/UseCase/HandleGetAllCountryUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetAll/UseCase/HandleGetAllCountryUseCaseHandlerTest.cs
@@ -1,0 +1,37 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Playground.Application.Features.Country.Query.GetAll.UseCase;
+using Playground.Application.Features.Country.Query.GetAll.Interface;
+using Playground.Application.Features.Country.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleGetAllCountryUseCaseHandlerTest
+    {
+        private readonly Mock<IGetAllCountryRepository> _mockRepo;
+        private readonly Mock<ILogger<GetAllCountryUseCaseHandler>> _mockLogger;
+        private readonly GetAllCountryUseCaseHandler _handler;
+
+        public HandleGetAllCountryUseCaseHandlerTest()
+        {
+            _mockRepo = new Mock<IGetAllCountryRepository>();
+            _mockLogger = new Mock<ILogger<GetAllCountryUseCaseHandler>>();
+            _handler = new GetAllCountryUseCaseHandler(_mockRepo.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoExecutado_DeveRetornarLista()
+        {
+            var list = new List<GetAllCountryOutput> { new GetAllCountryOutput { Name = "Brazil" } };
+
+            _mockRepo
+                .Setup(r => r.GetAllCountryAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(list);
+
+            var result = await _handler.Handle(new GetAllCountryQuery(), CancellationToken.None);
+
+            Assert.Equal(list, result);
+            _mockRepo.Verify(r => r.GetAllCountryAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonOutputTest.cs
@@ -1,0 +1,15 @@
+using Playground.Application.Features.Pokemon.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNamePokemonOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoNomeNaoVazio_DeveRetornarTrue()
+        {
+            var output = new GetByNamePokemonOutput { Name = "pikachu" };
+
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonQueryTest.cs
+++ b/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonQueryTest.cs
@@ -1,0 +1,27 @@
+using Playground.Application.Features.Pokemon.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNamePokemonQueryTest
+    {
+        [Fact]
+        public void SetName_DeveAlterarNome()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("pikachu");
+
+            Assert.Equal("pikachu", query.Name);
+        }
+
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("abc");
+
+            var warning = query.ToWarning();
+
+            Assert.Contains("Name:abc", warning);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Pokemon/GetByName/UseCase/HandleGetByNamePokemonUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/Pokemon/GetByName/UseCase/HandleGetByNamePokemonUseCaseHandlerTest.cs
@@ -1,0 +1,48 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Playground.Application.Features.Pokemon.GetByName.UseCase;
+using Playground.Application.Features.Pokemon.GetByName.Models;
+using Playground.Application.Shared.ExternalServices.Interfaces;
+using Playground.Application.Shared.Domain.ApiDto;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleGetByNamePokemonUseCaseHandlerTest
+    {
+        private readonly Mock<IPokemonApi> _mockPokemonApi;
+        private readonly Mock<ILogger<GetByNamePokemonUseCaseHandler>> _mockLogger;
+        private readonly GetByNamePokemonUseCaseHandler _handler;
+
+        public HandleGetByNamePokemonUseCaseHandlerTest()
+        {
+            _mockPokemonApi = new Mock<IPokemonApi>();
+            _mockLogger = new Mock<ILogger<GetByNamePokemonUseCaseHandler>>();
+            _handler = new GetByNamePokemonUseCaseHandler(_mockPokemonApi.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoExecutado_DeveRetornarPokemon()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("pikachu");
+
+            var apiDto = new PokemonOutApiDto
+            {
+                Name = "pikachu",
+                BaseExperience = 10,
+                LocationAreaEncounters = "url"
+            };
+
+            _mockPokemonApi
+                .Setup(api => api.GetByNameAsync("pikachu", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(apiDto);
+
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            Assert.Equal(apiDto.Name, result.Name);
+            Assert.Equal(apiDto.BaseExperience, result.BaseExperience);
+            Assert.Equal(apiDto.LocationAreaEncounters, result.LocationAreaEncounters);
+            _mockPokemonApi.Verify(api => api.GetByNameAsync("pikachu", It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommandTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommandTest.cs
@@ -1,0 +1,19 @@
+using Playground.Application.Features.ToDoItems.Command.Create.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class CreateToDoItemCommandTest
+    {
+        [Fact]
+        public void ErrosList_QuandoTaskVazia_DeveRetornarErro()
+        {
+            var command = new CreateToDoItemCommand { Task = "" };
+
+            var erros = command.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(command.IsInvalid());
+            Assert.Equal($"({string.Join("|", erros)})", command.FormattedErrosList());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Repositories/CreateTodoItemRepositoryTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Repositories/CreateTodoItemRepositoryTest.cs
@@ -1,0 +1,37 @@
+using Moq;
+using Moq.Dapper;
+using Dapper;
+using Playground.Application.Features.ToDoItems.Command.Create.Repositories;
+using Playground.Application.Features.ToDoItems.Command.Create.Models;
+using System.Data;
+
+namespace Playground.Tests.Controllers
+{
+    public class CreateTodoItemRepositoryTest
+    {
+        private readonly Mock<IDbConnection> _mockConnection;
+        private readonly CreateTodoItemRepository _repository;
+
+        public CreateTodoItemRepositoryTest()
+        {
+            _mockConnection = new Mock<IDbConnection>();
+            _repository = new CreateTodoItemRepository(_mockConnection.Object);
+        }
+
+        [Fact]
+        public async Task CreateToDoItemAsync_DeveExecutarQuery()
+        {
+            var command = new CreateToDoItemCommand { Task = "task" };
+            var expected = new CreateToDoItemOutput { Id = 1, Task = "task", IsCompleted = false };
+
+            _mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<CreateToDoItemOutput>(It.IsAny<CommandDefinition>()))
+                .ReturnsAsync(expected);
+
+            var result = await _repository.CreateToDoItemAsync(command, CancellationToken.None);
+
+            Assert.Equal(expected.Id, result.Id);
+            Assert.Equal(expected.Task, result.Task);
+            Assert.Equal(expected.IsCompleted, result.IsCompleted);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/UseCase/HandleCreateToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/UseCase/HandleCreateToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,35 @@
+using Moq;
+using Playground.Application.Features.ToDoItems.Command.Create.UseCase;
+using Playground.Application.Features.ToDoItems.Command.Create.Interface;
+using Playground.Application.Features.ToDoItems.Command.Create.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleCreateToDoItemUseCaseHandlerTest
+    {
+        private readonly Mock<ICreateTodoItemRepository> _mockRepo;
+        private readonly CreateToDoItemUseCaseHandler _handler;
+
+        public HandleCreateToDoItemUseCaseHandlerTest()
+        {
+            _mockRepo = new Mock<ICreateTodoItemRepository>();
+            _handler = new CreateToDoItemUseCaseHandler(_mockRepo.Object);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoExecutado_DeveRetornarItemCriado()
+        {
+            var command = new CreateToDoItemCommand { Task = "task" };
+            var expected = new CreateToDoItemOutput { Id = 1, Task = "task", IsCompleted = false };
+
+            _mockRepo
+                .Setup(r => r.CreateToDoItemAsync(command, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.Equal(expected, result);
+            _mockRepo.Verify(r => r.CreateToDoItemAsync(command, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/UseCase/HandleIsCompletedToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/UseCase/HandleIsCompletedToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,26 @@
+using Playground.Application.Features.ToDoItems.Command.PatchIsCompleted.UseCase;
+using Playground.Application.Features.ToDoItems.Command.PatchIsCompleted.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleIsCompletedToDoItemUseCaseHandlerTest
+    {
+        private readonly IsCompletedToDoItemUseCaseHandler _handler;
+
+        public HandleIsCompletedToDoItemUseCaseHandlerTest()
+        {
+            _handler = new IsCompletedToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_QuandoExecutado_DeveRetornarMesmoId()
+        {
+            var command = new IsCompletedToDoItemCommand { Id = 1, IsCompleted = true };
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.Equal(command.Id, result.Id);
+            Assert.True(result.IsCompleted);
+        }
+    }
+}

--- a/src/Playground.Tests/Playground.Tests.csproj
+++ b/src/Playground.Tests/Playground.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Moq.Dapper" Version="1.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- reference Moq.Dapper in test project
- add unit tests for several application layer use case handlers
- validate commands, queries and outputs
- test repository behaviors using Moq.Dapper

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln`

------
https://chatgpt.com/codex/tasks/task_e_6847b952317c832ca7f1ebd02f2cee53