### PR TITLE
Add feature layer tests

### DIFF
--- a/src/Playground.Tests/Application/Features/Country/Query/GetAll/Models/GetAllCountryOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetAll/Models/GetAllCountryOutputTest.cs
@@ -1,0 +1,15 @@
+using Playground.Application.Features.Country.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllCountryOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoNomeNaoVazio_DeveRetornarTrue()
+        {
+            var output = new GetAllCountryOutput { Name = "Brazil" };
+
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetAll/Models/GetAllCountryQueryTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetAll/Models/GetAllCountryQueryTest.cs
@@ -1,0 +1,19 @@
+using Playground.Application.Features.Country.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllCountryQueryTest
+    {
+        [Fact]
+        public void ErrosList_DeveEstarVazia()
+        {
+            var query = new GetAllCountryQuery();
+
+            var erros = query.ErrosList();
+
+            Assert.Empty(erros);
+            Assert.False(query.IsInvalid());
+            Assert.Equal("()", query.FormattedErrosList());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryOutputTest.cs
@@ -1,0 +1,15 @@
+using Playground.Application.Features.Country.Query.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameCountryOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoNomeNaoVazio_DeveRetornarTrue()
+        {
+            var output = new GetByNameCountryOutput { Name = "Brazil" };
+
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryQueryExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryQueryExtensionsTest.cs
@@ -1,0 +1,29 @@
+using Playground.Application.Features.Country.Query.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameCountryQueryExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("brazil");
+
+            var warning = query.ToWarning();
+
+            Assert.Equal("Name:brazil|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("brazil");
+
+            var info = query.ToInformation();
+
+            Assert.Equal("Name:brazil", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryQueryTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetByName/Models/GetByNameCountryQueryTest.cs
@@ -1,0 +1,28 @@
+using Playground.Application.Features.Country.Query.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameCountryQueryTest
+    {
+        [Fact]
+        public void SetName_DeveAlterarNome()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("Canada");
+
+            Assert.Equal("Canada", query.Name);
+        }
+
+        [Fact]
+        public void ErrosList_QuandoNomeVazio_DeveRetornarErro()
+        {
+            var query = new GetByNameCountryQuery();
+
+            var erros = query.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(query.IsInvalid());
+            Assert.Equal($"({string.Join("|", erros)})", query.FormattedErrosList());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetByName/Repositories/GetByNameCountryRepositoryTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetByName/Repositories/GetByNameCountryRepositoryTest.cs
@@ -1,0 +1,37 @@
+using Moq;
+using Moq.Dapper;
+using Dapper;
+using Playground.Application.Features.Country.Query.GetByName.Repositories;
+using Playground.Application.Features.Country.Query.GetByName.Models;
+using Playground.Application.Features.Country.Query.GetByName.Repositories.Script;
+using System.Data;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNameCountryRepositoryTest
+    {
+        private readonly Mock<IDbConnection> _mockConnection;
+        private readonly GetByNameCountryRepository _repository;
+
+        public GetByNameCountryRepositoryTest()
+        {
+            _mockConnection = new Mock<IDbConnection>();
+            _repository = new GetByNameCountryRepository(_mockConnection.Object);
+        }
+
+        [Fact]
+        public async Task GetByNameCountryAsync_DeveExecutarQuery()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("Brazil");
+            var expected = new GetByNameCountryOutput { Name = "Brazil" };
+
+            _mockConnection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<GetByNameCountryOutput>(It.IsAny<CommandDefinition>()))
+                .ReturnsAsync(expected);
+
+            var result = await _repository.GetByNameCountryAsync(query, CancellationToken.None);
+
+            Assert.Equal(expected.Name, result?.Name);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Country/Query/GetByName/UseCase/HandleGetByNameCountryUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/Country/Query/GetByName/UseCase/HandleGetByNameCountryUseCaseHandlerTest.cs
@@ -1,0 +1,37 @@
+using Playground.Application.Features.Country.Query.GetByName.UseCase;
+using Playground.Application.Features.Country.Query.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleGetByNameCountryUseCaseHandlerTest
+    {
+        private readonly GetByNameCountryUseCaseHandler _handler;
+
+        public HandleGetByNameCountryUseCaseHandlerTest()
+        {
+            _handler = new GetByNameCountryUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_QuandoNomeExistente_DeveRetornarPais()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("brazil");
+
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            Assert.Equal("Brazil", result.Name);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoNomeNaoExistente_DeveRetornarVazio()
+        {
+            var query = new GetByNameCountryQuery();
+            query.SetName("unknown");
+
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            Assert.Equal(string.Empty, result.Name);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonQueryExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/Pokemon/GetByName/Models/GetByNamePokemonQueryExtensionsTest.cs
@@ -1,0 +1,40 @@
+using Playground.Application.Features.Pokemon.GetByName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByNamePokemonQueryExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("pikachu");
+
+            var warning = query.ToWarning();
+
+            Assert.Equal("Name:pikachu|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToError_DeveGerarStringCorreta()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("pikachu");
+
+            var error = query.ToError();
+
+            Assert.Equal("Name:pikachu", error);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var query = new GetByNamePokemonQuery();
+            query.SetName("pikachu");
+
+            var info = query.ToInformation();
+
+            Assert.Equal("Name:pikachu", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommandExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateToDoItemCommandExtensionsTest.cs
@@ -1,0 +1,27 @@
+using Playground.Application.Features.ToDoItems.Command.Create.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class CreateToDoItemCommandExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var command = new CreateToDoItemCommand { Task = "task", IsCompleted = true };
+
+            var warning = command.ToWarning();
+
+            Assert.Equal("Task:task|IsCompleted:True|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var command = new CreateToDoItemCommand { Task = "task", IsCompleted = true };
+
+            var info = command.ToInformation();
+
+            Assert.Equal("Task:task|IsCompleted:True", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateTodoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Create/Models/CreateTodoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Command.Create.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class CreateTodoItemOutputTest
+    {
+        [Fact]
+        public void IsCreated_QuandoIdMaiorQueZero_DeveRetornarTrue()
+        {
+            var output = new CreateToDoItemOutput { Id = 1 };
+            Assert.True(output.IsCreated());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemCommandExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemCommandExtensionsTest.cs
@@ -1,0 +1,27 @@
+using Playground.Application.Features.ToDoItems.Command.Delete.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class DeleteToDoItemCommandExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var command = new DeleteToDoItemCommand(1);
+
+            var warning = command.ToWarning();
+
+            Assert.Equal("Id:1|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var command = new DeleteToDoItemCommand(1);
+
+            var info = command.ToInformation();
+
+            Assert.Equal("Id:1", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemCommandTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemCommandTest.cs
@@ -1,0 +1,19 @@
+using Playground.Application.Features.ToDoItems.Command.Delete.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class DeleteToDoItemCommandTest
+    {
+        [Fact]
+        public void ErrosList_QuandoIdInvalido_DeveRetornarErro()
+        {
+            var command = new DeleteToDoItemCommand(0);
+
+            var erros = command.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(command.IsInvalid());
+            Assert.Equal($"({string.Join("|", erros)})", command.FormattedErrosList());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/Models/DeleteToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Command.Delete.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class DeleteToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_DeveRetornarTrue()
+        {
+            var output = new DeleteToDoItemOutput();
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/UseCase/HandleDeleteToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Delete/UseCase/HandleDeleteToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,25 @@
+using Playground.Application.Features.ToDoItems.Command.Delete.UseCase;
+using Playground.Application.Features.ToDoItems.Command.Delete.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleDeleteToDoItemUseCaseHandlerTest
+    {
+        private readonly DeleteToDoItemUseCaseHandler _handler;
+
+        public HandleDeleteToDoItemUseCaseHandlerTest()
+        {
+            _handler = new DeleteToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_DeveRetornarOutputValido()
+        {
+            var command = new DeleteToDoItemCommand(1);
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.True(result.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemCommandExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemCommandExtensionsTest.cs
@@ -1,0 +1,27 @@
+using Playground.Application.Features.ToDoItems.Command.PatchIsCompleted.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class IsCompletedToDoItemCommandExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var command = new IsCompletedToDoItemCommand { Id = 1, IsCompleted = true };
+
+            var warning = command.ToWarning();
+
+            Assert.Equal("Id:1|IsCompleted:True|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var command = new IsCompletedToDoItemCommand { Id = 1, IsCompleted = true };
+
+            var info = command.ToInformation();
+
+            Assert.Equal("Id:1|IsCompleted:True", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemCommandTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemCommandTest.cs
@@ -1,0 +1,30 @@
+using Playground.Application.Features.ToDoItems.Command.PatchIsCompleted.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class IsCompletedToDoItemCommandTest
+    {
+        [Fact]
+        public void Setters_DeveAlterarValores()
+        {
+            var command = new IsCompletedToDoItemCommand();
+            command.SetId(5);
+            command.SetIsCompleted(true);
+
+            Assert.Equal(5, command.Id);
+            Assert.True(command.IsCompleted);
+        }
+
+        [Fact]
+        public void ErrosList_QuandoIdInvalido_DeveRetornarErro()
+        {
+            var command = new IsCompletedToDoItemCommand();
+            command.SetId(0);
+
+            var erros = command.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(command.IsInvalid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchIsCompleted/Models/IsCompletedToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Command.PatchIsCompleted.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class IsCompletedToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoIdValido_DeveRetornarTrue()
+        {
+            var output = new IsCompletedToDoItemOutput { Id = 2, IsCompleted = true };
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemCommandExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemCommandExtensionsTest.cs
@@ -1,0 +1,27 @@
+using Playground.Application.Features.ToDoItems.Command.PatchTaskName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class PatchTaskNameToDoItemCommandExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var command = new PatchTaskNameToDoItemCommand { Id = 1, TaskName = "name" };
+
+            var warning = command.ToWarning();
+
+            Assert.Equal("Id:1|TaskName:name|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var command = new PatchTaskNameToDoItemCommand { Id = 1, TaskName = "name" };
+
+            var info = command.ToInformation();
+
+            Assert.Equal("Id:1|TaskName:name", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemCommandTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemCommandTest.cs
@@ -1,0 +1,31 @@
+using Playground.Application.Features.ToDoItems.Command.PatchTaskName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class PatchTaskNameToDoItemCommandTest
+    {
+        [Fact]
+        public void Setters_DeveAlterarValores()
+        {
+            var command = new PatchTaskNameToDoItemCommand();
+            command.SetId(10);
+            command.SetTaskName("update");
+
+            Assert.Equal(10, command.Id);
+            Assert.Equal("update", command.TaskName);
+        }
+
+        [Fact]
+        public void ErrosList_QuandoDadosInvalidos_DeveRetornarErro()
+        {
+            var command = new PatchTaskNameToDoItemCommand();
+            command.SetId(0);
+            command.SetTaskName("");
+
+            var erros = command.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(command.IsInvalid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/Models/PatchTaskNameToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Command.PatchTaskName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class PatchTaskNameToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoDadosValidos_DeveRetornarTrue()
+        {
+            var output = new PatchTaskNameToDoItemOutput { Id = 1, Task = "task", IsCompleted = false };
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/UseCase/HandlePatchTaskNameToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/PatchTaskName/UseCase/HandlePatchTaskNameToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,26 @@
+using Playground.Application.Features.ToDoItems.Command.PatchTaskName.UseCase;
+using Playground.Application.Features.ToDoItems.Command.PatchTaskName.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandlePatchTaskNameToDoItemUseCaseHandlerTest
+    {
+        private readonly PatchTaskNameToDoItemUseCaseHandler _handler;
+
+        public HandlePatchTaskNameToDoItemUseCaseHandlerTest()
+        {
+            _handler = new PatchTaskNameToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_DeveRetornarOutputComMesmoId()
+        {
+            var command = new PatchTaskNameToDoItemCommand { Id = 7, TaskName = "do" };
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.Equal(7, result.Id);
+            Assert.Equal("do", result.Task);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemCommandExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemCommandExtensionsTest.cs
@@ -1,0 +1,29 @@
+using Playground.Application.Features.ToDoItems.Command.Update.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class UpdateToDoItemCommandExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var command = new UpdateToDoItemCommand { Task = "a", IsCompleted = true };
+            command.SetId(1);
+
+            var warning = command.ToWarning();
+
+            Assert.Equal("Id:1|Task:a|IsCompleted:True|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var command = new UpdateToDoItemCommand { Task = "a", IsCompleted = true };
+            command.SetId(1);
+
+            var info = command.ToInformation();
+
+            Assert.Equal("Id:1|Task:a|IsCompleted:True", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemCommandTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemCommandTest.cs
@@ -1,0 +1,33 @@
+using Playground.Application.Features.ToDoItems.Command.Update.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class UpdateToDoItemCommandTest
+    {
+        [Fact]
+        public void Setters_DeveAlterarValores()
+        {
+            var command = new UpdateToDoItemCommand();
+            command.SetId(8);
+            command.Task = "task";
+            command.IsCompleted = true;
+
+            Assert.Equal(8, command.Id);
+            Assert.Equal("task", command.Task);
+            Assert.True(command.IsCompleted);
+        }
+
+        [Fact]
+        public void ErrosList_QuandoDadosInvalidos_DeveRetornarErro()
+        {
+            var command = new UpdateToDoItemCommand();
+            command.SetId(0);
+            command.Task = "";
+
+            var erros = command.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(command.IsInvalid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/Models/UpdateToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Command.Update.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class UpdateToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoDadosValidos_DeveRetornarTrue()
+        {
+            var output = new UpdateToDoItemOutput { Id = 1, Task = "task", IsCompleted = true };
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/UseCase/HandleUpdateToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Command/Update/UseCase/HandleUpdateToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,28 @@
+using Playground.Application.Features.ToDoItems.Command.Update.UseCase;
+using Playground.Application.Features.ToDoItems.Command.Update.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleUpdateToDoItemUseCaseHandlerTest
+    {
+        private readonly UpdateToDoItemUseCaseHandler _handler;
+
+        public HandleUpdateToDoItemUseCaseHandlerTest()
+        {
+            _handler = new UpdateToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_DeveRetornarOutputComMesmoId()
+        {
+            var command = new UpdateToDoItemCommand { Task = "task", IsCompleted = true };
+            command.SetId(2);
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.Equal(2, result.Id);
+            Assert.Equal("task", result.Task);
+            Assert.True(result.IsCompleted);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/Models/GetAllToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/Models/GetAllToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoDadosValidos_DeveRetornarTrue()
+        {
+            var output = new GetAllToDoItemOutput { Id = 1, Task = "task", IsCompleted = false };
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/Models/GetAllToDoItemQueryTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/Models/GetAllToDoItemQueryTest.cs
@@ -1,0 +1,17 @@
+using Playground.Application.Features.ToDoItems.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetAllToDoItemQueryTest
+    {
+        [Fact]
+        public void ErrosList_DeveEstarVazia()
+        {
+            var query = new GetAllToDoItemQuery();
+
+            Assert.Empty(query.ErrosList());
+            Assert.False(query.IsInvalid());
+            Assert.Equal("()", query.FormattedErrosList());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/UseCase/HandleGetAllToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetAll/UseCase/HandleGetAllToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,23 @@
+using Playground.Application.Features.ToDoItems.Query.GetAll.UseCase;
+using Playground.Application.Features.ToDoItems.Query.GetAll.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleGetAllToDoItemUseCaseHandlerTest
+    {
+        private readonly GetAllToDoItemUseCaseHandler _handler;
+
+        public HandleGetAllToDoItemUseCaseHandlerTest()
+        {
+            _handler = new GetAllToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_DeveRetornarListaPreenchida()
+        {
+            var result = await _handler.Handle(new GetAllToDoItemQuery(), CancellationToken.None);
+
+            Assert.NotEmpty(result);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemOutputTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemOutputTest.cs
@@ -1,0 +1,14 @@
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByIdToDoItemOutputTest
+    {
+        [Fact]
+        public void IsValid_QuandoDadosValidos_DeveRetornarTrue()
+        {
+            var output = new GetByIdToDoItemOutput { Id = 1, Task = "task", IsCompleted = false };
+            Assert.True(output.IsValid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemQueryExtensionsTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemQueryExtensionsTest.cs
@@ -1,0 +1,29 @@
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByIdToDoItemQueryExtensionsTest
+    {
+        [Fact]
+        public void ToWarning_DeveGerarStringCorreta()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(4);
+
+            var warning = query.ToWarning();
+
+            Assert.Equal("Id:4|FormattedErrosList:()", warning);
+        }
+
+        [Fact]
+        public void ToInformation_DeveGerarStringCorreta()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(4);
+
+            var info = query.ToInformation();
+
+            Assert.Equal("Id:4", info);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemQueryTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/Models/GetByIdToDoItemQueryTest.cs
@@ -1,0 +1,28 @@
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class GetByIdToDoItemQueryTest
+    {
+        [Fact]
+        public void SetId_DeveAlterarId()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(3);
+
+            Assert.Equal(3, query.Id);
+        }
+
+        [Fact]
+        public void ErrosList_QuandoIdInvalido_DeveRetornarErro()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(0);
+
+            var erros = query.ErrosList().ToList();
+
+            Assert.NotEmpty(erros);
+            Assert.True(query.IsInvalid());
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/UseCase/HandleGetByIdToDoItemUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/ToDoItems/Query/GetById/UseCase/HandleGetByIdToDoItemUseCaseHandlerTest.cs
@@ -1,0 +1,38 @@
+using Playground.Application.Features.ToDoItems.Query.GetById.UseCase;
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+
+namespace Playground.Tests.Controllers
+{
+    public class HandleGetByIdToDoItemUseCaseHandlerTest
+    {
+        private readonly GetByIdToDoItemUseCaseHandler _handler;
+
+        public HandleGetByIdToDoItemUseCaseHandlerTest()
+        {
+            _handler = new GetByIdToDoItemUseCaseHandler();
+        }
+
+        [Fact]
+        public async Task Handle_QuandoIdExistente_DeveRetornarItem()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(99);
+
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            Assert.Equal(99, result.Id);
+            Assert.NotEmpty(result.Task);
+        }
+
+        [Fact]
+        public async Task Handle_QuandoIdNaoExistente_DeveRetornarVazio()
+        {
+            var query = new GetByIdToDoItemQuery();
+            query.SetId(1);
+
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            Assert.Equal(0, result.Id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for country `GetByName` query & handler
- cover remaining ToDoItems command/query handlers and models
- include extra tests for Pokemon query extensions
- extend GetAll country tests

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6847b07cb940832cb54a3b9a4ff18174