### PR TITLE
Fix tests to verify mediator calls

### DIFF
--- a/src/Playground.Tests/Api/Controller/ToDoItemController/CreateToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/CreateToDoItemControllerTest.cs
@@ -44,6 +44,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status201Created, response.StatusCode);
             Assert.Equal(_validOutput, response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -60,6 +63,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<CreateToDoItemCommand>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/ToDoItemController/GetAllToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/GetAllToDoItemControllerTest.cs
@@ -46,6 +46,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.Equal(output, responseData);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetAllToDoItemQuery>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -63,6 +66,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<NoContentResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetAllToDoItemQuery>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/ToDoItemController/GetByIdToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/GetByIdToDoItemControllerTest.cs
@@ -52,6 +52,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -68,6 +71,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<GetByIdToDoItemQuery>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -83,6 +89,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<NoContentResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/ToDoItemController/PatchTaskNameToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/PatchTaskNameToDoItemControllerTest.cs
@@ -58,6 +58,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<OkResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -74,6 +77,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<PatchTaskNameToDoItemCommand>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -89,6 +95,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<NoContentResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status204NoContent, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Playground.Tests/Api/Controller/ToDoItemController/UpdateToDoItemControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/ToDoItemController/UpdateToDoItemControllerTest.cs
@@ -48,6 +48,9 @@ namespace Playground.Tests.Controllers
             var response = Assert.IsType<OkResult>(actionResult);
 
             Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            _mockMediator.Verify(m =>
+                m.Send(_validInput, It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]
@@ -64,6 +67,9 @@ namespace Playground.Tests.Controllers
 
             Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
             Assert.NotNull(response.Value);
+            _mockMediator.Verify(m =>
+                m.Send(It.IsAny<UpdateToDoItemCommand>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Verify checks on mediator calls in ToDoItemController tests

## Testing
- `dotnet build src/Playground.Ecs.sln -c Release` *(fails: command not found)*
- `dotnet test src/Playground.Ecs.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa773fd38832ca9c6584b05050872