### PR TITLE
Add workflow to publish docs to Wiki

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,20 @@
+name: Publish Wiki
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Publish documentation to Wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: wiki
+          commit-message: Update wiki ${{ github.event.pull_request.merge_commit_sha }}

--- a/wiki/Infrastructure.md
+++ b/wiki/Infrastructure.md
@@ -12,3 +12,6 @@ dotnet build src/Playground.Ecs.sln -c Release --no-restore
 ```bash
 dotnet test src/Playground.Ecs.sln -c Release --no-build
 ```
+
+## GitHub Actions
+A workflow publishes the contents of the `wiki` folder to the repository Wiki whenever a pull request is merged into `main`. The file is `.github/workflows/publish-wiki.yml` and it uses `Andrew-Chen-Wang/github-wiki-action`.

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -38,3 +38,8 @@ Separe a documentação das funcionalidades da documentação de exemplos, os ex
 ```
 Na documentação das controles e suas actions, existentes, coloque a action por completo, colocando toda a sua lógica para exemplificar como criar novas actions. No arquivo de Agents, adicione o comando de que toda a nova funcionalidade deve ser consultada nos arquivos de exemplo e esses exemplos devem ser seguidos para a criação dessas novas funcionalidades. Tanto Actions, nas Controllers, quanto Features, Repositórios, middlewares, etc. Na documentação de Features e Controllers de Exemplos, cada arquivo de exemplo deve ser um documento de documentação separado, e a organização desses arquivos deve seguir a mesma estrutura de pastas das suas respectivas controllers ou features.
 ```
+
+## Pedido 8
+```
+Os arquivos de documentação não estão aparecendo na Wiki. Crie uma Action para publicá-los sempre que um pull request for mergeado para main.
+```


### PR DESCRIPTION
## Summary
- publish `wiki` folder to GitHub Wiki when PRs are merged to `main`
- document workflow in Infrastructure docs
- log new user request

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852b803e610832c962bc4350a31dfea