### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,20 @@
+name: Executar Benchmark
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore src/Playground.Ecs.sln
+      - name: Run benchmark
+        run: dotnet run --project src/Playground.Benchmarks/Playground.Benchmarks.csproj -c Release

--- a/src/Playground.Benchmarks/GetByIdToDoItemUseCaseHandlerBenchmark.cs
+++ b/src/Playground.Benchmarks/GetByIdToDoItemUseCaseHandlerBenchmark.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Playground.Application.Features.ToDoItems.Query.GetById.Models;
+using Playground.Application.Features.ToDoItems.Query.GetById.UseCase;
+
+namespace Playground.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class GetByIdToDoItemUseCaseHandlerBenchmark
+    {
+        private GetByIdToDoItemUseCaseHandler _handler = null!;
+        private GetByIdToDoItemQuery _query = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _handler = new GetByIdToDoItemUseCaseHandler();
+            _query = new GetByIdToDoItemQuery();
+            _query.SetId(99);
+        }
+
+        [Benchmark]
+        public async Task<GetByIdToDoItemOutput> HandleAsync()
+        {
+            return await _handler.Handle(_query, CancellationToken.None);
+        }
+    }
+}

--- a/src/Playground.Benchmarks/Playground.Benchmarks.csproj
+++ b/src/Playground.Benchmarks/Playground.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Playground.Application\Playground.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Playground.Benchmarks/Program.cs
+++ b/src/Playground.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkRunner.Run<Playground.Benchmarks.GetByIdToDoItemUseCaseHandlerBenchmark>();

--- a/src/Playground.Ecs.sln
+++ b/src/Playground.Ecs.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Playground.Application", "P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.Tests", "Playground.Tests\Playground.Tests.csproj", "{7A59D9C7-F449-4739-A763-2600B30AE4C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground.Benchmarks", "Playground.Benchmarks\Playground.Benchmarks.csproj", "{5513A7D6-BE62-4870-B133-70B89E053BFD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{7A59D9C7-F449-4739-A763-2600B30AE4C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A59D9C7-F449-4739-A763-2600B30AE4C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A59D9C7-F449-4739-A763-2600B30AE4C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5513A7D6-BE62-4870-B133-70B89E053BFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5513A7D6-BE62-4870-B133-70B89E053BFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5513A7D6-BE62-4870-B133-70B89E053BFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5513A7D6-BE62-4870-B133-70B89E053BFD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wiki/Infrastructure.md
+++ b/wiki/Infrastructure.md
@@ -15,3 +15,4 @@ dotnet test src/Playground.Ecs.sln -c Release --no-build
 
 ## GitHub Actions
 A workflow publishes the contents of the `wiki` folder to the repository Wiki whenever a pull request is merged into `main`. The file is `.github/workflows/publish-wiki.yml` and it uses `Andrew-Chen-Wang/github-wiki-action`.
+Another workflow '.github/workflows/benchmark.yml' executes the BenchmarkDotNet project whenever a pull request is opened or synchronized.

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -86,3 +86,12 @@ Ao invés de importar essa action, é possível colocar o código inteiro aqui? 
 ```
 Pesquise na internet se é dessa maneira que adiciona um pull request a um projeto, através de uma action
 ```
+## Pedido 13
+```
+usando o framework Benchmark.net, faça um teste de performance da classe GetByIdToDoItemUseCaseHandler, crie um projeto a parte para armazenar esse tipo de teste
+```
+
+## Pedido 14
+```
+Crie uma action para rodar esse teste quando abrir ou atualizar um pull request
+```


### PR DESCRIPTION
## Summary
- create GitHub action to run BenchmarkDotNet on PR events
- document the new workflow in Infrastructure docs
- log the user's request in the history

## Testing
- `dotnet restore src/Playground.Ecs.sln --no-cache --ignore-failed-sources`
- `dotnet build src/Playground.Ecs.sln -c Release --no-restore`
- `dotnet test src/Playground.Ecs.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6853561d13a8832c9c9148874ba19016