### PR TITLE
Improve benchmark performance

### DIFF
--- a/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
+++ b/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
@@ -5,20 +5,20 @@ namespace Playground.Application.Features.ToDoItems.Query.GetById.UseCase
 {
     public class GetByIdToDoItemUseCaseHandler : IRequestHandler<GetByIdToDoItemQuery, GetByIdToDoItemOutput>
     {
+        private static readonly Dictionary<long, GetByIdToDoItemOutput> _items = new()
+        {
+            [99] = new GetByIdToDoItemOutput
+            {
+                Id = 99,
+                Task = "GetById - ToDoItem - UseCaseHandler",
+                IsCompleted = true
+            }
+        };
+
         public Task<GetByIdToDoItemOutput> Handle(GetByIdToDoItemQuery input, CancellationToken cancellationToken)
         {
-            var items = new List<GetByIdToDoItemOutput>
-            {
-                new GetByIdToDoItemOutput
-                {
-                    Id = 99,
-                    Task = "GetById - ToDoItem - UseCaseHandler",
-                    IsCompleted = true
-                }
-            };
-
-            var result = items.SingleOrDefault(item => item.Id == input.Id) ?? new GetByIdToDoItemOutput();
-            return Task.FromResult(result);
+            _items.TryGetValue(input.Id, out var result);
+            return Task.FromResult(result ?? new GetByIdToDoItemOutput());
         }
     }
 }

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -128,3 +128,8 @@ Enter the asterisk `*` to select all.
 To print all available benchmarks use `--list flat` or `--list tree`.
 To learn more about filtering use `--help`.
 ```
+
+## Pedido 20
+```
+Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```


### PR DESCRIPTION
## Summary
- improve GetByIdToDoItemUseCaseHandler performance using a static dictionary
- log the user request in the wiki

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln --no-build`
- `dotnet run --project src/Playground.Benchmarks/Playground.Benchmarks.csproj -c Release -- --filter '*'`

------
https://chatgpt.com/codex/tasks/task_e_68545f603d48832ca67a2847d61d0b4d