### PR TITLE
Improve benchmark performance

### DIFF
--- a/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
+++ b/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
@@ -5,20 +5,16 @@ namespace Playground.Application.Features.ToDoItems.Query.GetById.UseCase
 {
     public class GetByIdToDoItemUseCaseHandler : IRequestHandler<GetByIdToDoItemQuery, GetByIdToDoItemOutput>
     {
+        private static readonly GetByIdToDoItemOutput CachedItem = new()
+        {
+            Id = 99,
+            Task = "GetById - ToDoItem - UseCaseHandler",
+            IsCompleted = true
+        };
+
         public Task<GetByIdToDoItemOutput> Handle(GetByIdToDoItemQuery input, CancellationToken cancellationToken)
         {
-            var items = new List<GetByIdToDoItemOutput>
-            {
-                new GetByIdToDoItemOutput
-                {
-                    Id = 99,
-                    Task = "GetById - ToDoItem - UseCaseHandler",
-                    IsCompleted = true
-                }
-            };
-
-            var result = items.SingleOrDefault(item => item.Id == input.Id) ?? new GetByIdToDoItemOutput();
-            return Task.FromResult(result);
+            return Task.FromResult(input.Id == CachedItem.Id ? CachedItem : new GetByIdToDoItemOutput());
         }
     }
 }

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -128,3 +128,13 @@ Enter the asterisk `*` to select all.
 To print all available benchmarks use `--list flat` or `--list tree`.
 To learn more about filtering use `--help`.
 ```
+
+## Pedido 20
+```
+Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```
+
+## Pedido 21
+```
+Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```


### PR DESCRIPTION
## Summary
- refine GetByIdToDoItemUseCaseHandler for constant-time access
- log the repeated user request

## Testing
- `dotnet run --project src/Playground.Benchmarks/Playground.Benchmarks.csproj -c Release -- --filter '*'` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545f603d48832ca67a2847d61d0b4d