### PR TITLE
Improve benchmark performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ msbuild.wrn
 _NCrunch_Sistema
 
 # Detritus
-*.ncrunchsolution
+*.ncrunchsolutionBenchmarkDotNet.Artifacts/

--- a/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
+++ b/src/Playground.Application/Features/ToDoItems/Query/GetById/UseCase/GetByIdToDoItemUseCaseHandler.cs
@@ -1,24 +1,34 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Caching.Memory;
 using Playground.Application.Features.ToDoItems.Query.GetById.Models;
 
 namespace Playground.Application.Features.ToDoItems.Query.GetById.UseCase
 {
     public class GetByIdToDoItemUseCaseHandler : IRequestHandler<GetByIdToDoItemQuery, GetByIdToDoItemOutput>
     {
+        private static readonly MemoryCache MemoryCache = new(new MemoryCacheOptions());
+
+        private static readonly GetByIdToDoItemOutput CachedItem = new()
+        {
+            Id = 99,
+            Task = "GetById - ToDoItem - UseCaseHandler",
+            IsCompleted = true
+        };
+
+        private const string CacheKey = "GetByIdToDoItem";
+
         public Task<GetByIdToDoItemOutput> Handle(GetByIdToDoItemQuery input, CancellationToken cancellationToken)
         {
-            var items = new List<GetByIdToDoItemOutput>
-            {
-                new GetByIdToDoItemOutput
-                {
-                    Id = 99,
-                    Task = "GetById - ToDoItem - UseCaseHandler",
-                    IsCompleted = true
-                }
-            };
+            if (input.Id != CachedItem.Id)
+                return Task.FromResult(new GetByIdToDoItemOutput());
 
-            var result = items.SingleOrDefault(item => item.Id == input.Id) ?? new GetByIdToDoItemOutput();
-            return Task.FromResult(result);
+            if (!MemoryCache.TryGetValue(CacheKey, out GetByIdToDoItemOutput? item))
+            {
+                item = CachedItem;
+                MemoryCache.Set(CacheKey, item, TimeSpan.FromMinutes(1));
+            }
+
+            return Task.FromResult(item!);
         }
     }
 }

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -128,3 +128,23 @@ Enter the asterisk `*` to select all.
 To print all available benchmarks use `--list flat` or `--list tree`.
 To learn more about filtering use `--help`.
 ```
+
+## Pedido 20
+```
+Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```
+
+## Pedido 21
+```
+Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```
+
+## Pedido 22
+```
+Alterando o que for necessario, melhore sua performance da classe GetByIdToDoItemUseCaseHandler. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
+```
+
+## Pedido 23
+```
+Para tentar maximizar o desempenho, utilize memory cache
+```


### PR DESCRIPTION
## Summary
- refine `GetByIdToDoItemUseCaseHandler` with `MemoryCache`
- log the additional optimization request
- ignore benchmark artifacts

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln --no-build`
- `dotnet run --project src/Playground.Benchmarks/Playground.Benchmarks.csproj -c Release -- --filter '*'`


------
https://chatgpt.com/codex/tasks/task_e_68545f603d48832ca67a2847d61d0b4d