### PR TITLE
Refactor OpenIA integration feature

### DIFF
--- a/src/Playground.API/Controllers/OpenIaIntegrationController.cs
+++ b/src/Playground.API/Controllers/OpenIaIntegrationController.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models;
+using System.Net;
+
+namespace Playground.API.Controllers
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("openia")]
+    [Produces("application/json")]
+    [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+    public class OpenIaIntegrationController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+        private readonly ILogger<OpenIaIntegrationController> _logger;
+
+        public OpenIaIntegrationController(IMediator mediator, ILogger<OpenIaIntegrationController> logger)
+        {
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        [HttpPost("prompt")]
+        [ProducesResponseType(typeof(SendPromptOutput), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> SendPromptAsync([FromBody] SendPromptCommand input, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"[Api][OpenIaIntegrationController][SendPromptAsync][Start] input:({input.ToInformation()})");
+
+            if (input.IsInvalid())
+            {
+                _logger.LogWarning($"[Api][OpenIaIntegrationController][SendPromptAsync][BadRequest] input:({input.ToWarning()})");
+                return BadRequest(input.ErrosList());
+            }
+
+            var output = await _mediator.Send(input, cancellationToken);
+
+            _logger.LogInformation($"[Api][OpenIaIntegrationController][SendPromptAsync][Ok] input:({input.ToInformation()})");
+            return Ok(output);
+        }
+    }
+}

--- a/src/Playground.API/appsettings.json
+++ b/src/Playground.API/appsettings.json
@@ -10,12 +10,16 @@
   },
   "AllowedHosts": "*",
   "ExternalApiOptions": {
-    //"PokemonApiUrl": "https://pokeapi.co/api/v2",
-    "PokemonApiUrl": "https://localhost:7066/",
-
-    "PokemonApiRetryCount": 3,
-    "PokemonApiSleepDuration": 2,
-    "PokemonApiTimeout": 10
+    "PokemonApi": {
+      "Url": "https://localhost:7066/",
+      "RetryCount": 3,
+      "SleepDuration": 2,
+      "Timeout": 10
+    },
+    "OpenIaApi": {
+      "Url": "https://api.openai.com/v1",
+      "ApiKey": ""
+    }
   },
   "ConnectionStrings": {
     "MySqlConnectionString": "server=localhost;user id=admin;password=123456;database=world;"

--- a/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptCommand.cs
+++ b/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptCommand.cs
@@ -1,0 +1,31 @@
+using Flunt.Notifications;
+using Flunt.Validations;
+using MediatR;
+using Playground.Application.Shared.Features.Models;
+using System.Text.Json.Serialization;
+
+namespace Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models
+{
+    public class SendPromptCommand : ValidatableInputBase, IRequest<SendPromptOutput>
+    {
+        [JsonPropertyName("prompt")]
+        public string Prompt { get; set; } = string.Empty;
+
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "gpt-3.5-turbo";
+
+        [JsonPropertyName("temperature")]
+        public float Temperature { get; set; } = 1f;
+
+        public override IEnumerable<string> ErrosList()
+        {
+            var contract = new Contract<Notification>()
+                .Requires()
+                .IsNotNullOrEmpty(Prompt, nameof(Prompt), $"{nameof(Prompt)} deve estar preenchido")
+                .IsNotNullOrEmpty(Model, nameof(Model), $"{nameof(Model)} deve estar preenchido")
+                .IsBetween(Temperature, 0, 2, nameof(Temperature), $"{nameof(Temperature)} deve estar entre 0 e 2");
+
+            return GenerateErrorList(contract);
+        }
+    }
+}

--- a/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptCommandExtensions.cs
+++ b/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptCommandExtensions.cs
@@ -1,0 +1,15 @@
+namespace Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models
+{
+    public static class SendPromptCommandExtensions
+    {
+        public static string ToWarning(this SendPromptCommand input)
+        {
+            return $"{nameof(input.Prompt)}:{input.Prompt}|{nameof(input.Model)}:{input.Model}|{nameof(input.Temperature)}:{input.Temperature}|{nameof(input.FormattedErrosList)}:{input.FormattedErrosList()}";
+        }
+
+        public static string ToInformation(this SendPromptCommand input)
+        {
+            return $"{nameof(input.Prompt)}:{input.Prompt}|{nameof(input.Model)}:{input.Model}|{nameof(input.Temperature)}:{input.Temperature}";
+        }
+    }
+}

--- a/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptOutput.cs
+++ b/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/Models/SendPromptOutput.cs
@@ -1,0 +1,9 @@
+namespace Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models
+{
+    public class SendPromptOutput
+    {
+        public string Response { get; set; } = string.Empty;
+
+        public bool IsValid() => !string.IsNullOrWhiteSpace(Response);
+    }
+}

--- a/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/UseCase/SendPromptUseCaseHandler.cs
+++ b/src/Playground.Application/Features/OpenIaIntegration/Command/SendPrompt/UseCase/SendPromptUseCaseHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models;
+using Playground.Application.Shared.Domain.OpenAi;
+using Playground.Application.Shared.ExternalServices.Interfaces;
+
+namespace Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.UseCase
+{
+    public class SendPromptUseCaseHandler : IRequestHandler<SendPromptCommand, SendPromptOutput>
+    {
+        private readonly IOpenAiApi _openAiApi;
+        private readonly ILogger<SendPromptUseCaseHandler> _logger;
+
+        public SendPromptUseCaseHandler(IOpenAiApi openAiApi, ILogger<SendPromptUseCaseHandler> logger)
+        {
+            _openAiApi = openAiApi;
+            _logger = logger;
+        }
+
+        public async Task<SendPromptOutput> Handle(SendPromptCommand input, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("[SendPromptUseCaseHandler][Handle] Enviando prompt para OpenAI");
+
+            var request = new ChatGptRequestDto
+            {
+                Model = input.Model,
+                Temperature = input.Temperature,
+                Messages = new List<ChatGptMessageDto>
+                {
+                    new() { Role = "user", Content = input.Prompt }
+                }
+            };
+
+            var response = await _openAiApi.SendPromptAsync(request, cancellationToken);
+
+            var output = new SendPromptOutput
+            {
+                Response = response.Choices.FirstOrDefault()?.Message.Content ?? string.Empty
+            };
+
+            _logger.LogInformation("[SendPromptUseCaseHandler][Handle] Resposta obtida");
+
+            return output;
+        }
+    }
+}

--- a/src/Playground.Application/Infrastructure/Configuration/ExternalApiOptions.cs
+++ b/src/Playground.Application/Infrastructure/Configuration/ExternalApiOptions.cs
@@ -1,10 +1,22 @@
-﻿namespace Playground.Application.Infrastructure.Configuration
+namespace Playground.Application.Infrastructure.Configuration
 {
     public class ExternalApiOptions
     {
-        public string PokemonApiUrl { get; set; } = string.Empty;
-        public TimeSpan PokemonApiTimeout { get; set; }
-        public int PokemonApiRetryCount { get; set; }
-        public int PokemonApiSleepDuration { get; set; }
+        public PokemonApiOptions PokemonApi { get; set; } = new();
+        public OpenIaApiOptions OpenIaApi { get; set; } = new();
+    }
+
+    public class PokemonApiOptions
+    {
+        public string Url { get; set; } = string.Empty;
+        public TimeSpan Timeout { get; set; }
+        public int RetryCount { get; set; }
+        public int SleepDuration { get; set; }
+    }
+
+    public class OpenIaApiOptions
+    {
+        public string Url { get; set; } = string.Empty;
+        public string ApiKey { get; set; } = string.Empty;
     }
 }

--- a/src/Playground.Application/Playground.Application.csproj
+++ b/src/Playground.Application/Playground.Application.csproj
@@ -32,6 +32,8 @@
     <Folder Include="Features\ToDoItems\Query\GetById\Interface\" />
     <Folder Include="Features\ToDoItems\Query\GetById\Repositories\Script\" />
     <Folder Include="Features\ToDoItems\Command\Create\Entities\" />
+    <Folder Include="Features\OpenIaIntegration\Command\SendPrompt\Models\" />
+    <Folder Include="Features\OpenIaIntegration\Command\SendPrompt\UseCase\" />
     <Folder Include="Shared\Factories\" />
   </ItemGroup>
 

--- a/src/Playground.Application/Shared/AutofacModules/ApiModules.cs
+++ b/src/Playground.Application/Shared/AutofacModules/ApiModules.cs
@@ -9,6 +9,7 @@ namespace Playground.Application.Shared.AutofacModules
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<PokemonApi>().As<IPokemonApi>();
+            builder.RegisterType<OpenAiApi>().As<IOpenAiApi>();
         }
     }
 }

--- a/src/Playground.Application/Shared/Domain/OpenAi/ChatGptMessageDto.cs
+++ b/src/Playground.Application/Shared/Domain/OpenAi/ChatGptMessageDto.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Playground.Application.Shared.Domain.OpenAi
+{
+    public class ChatGptMessageDto
+    {
+        [JsonPropertyName("role")]
+        public string Role { get; set; } = string.Empty;
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/src/Playground.Application/Shared/Domain/OpenAi/ChatGptRequestDto.cs
+++ b/src/Playground.Application/Shared/Domain/OpenAi/ChatGptRequestDto.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Playground.Application.Shared.Domain.OpenAi
+{
+    public class ChatGptRequestDto
+    {
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "gpt-3.5-turbo";
+
+        [JsonPropertyName("temperature")]
+        public float Temperature { get; set; } = 1f;
+
+        [JsonPropertyName("messages")]
+        public IEnumerable<ChatGptMessageDto> Messages { get; set; } = Enumerable.Empty<ChatGptMessageDto>();
+    }
+}

--- a/src/Playground.Application/Shared/Domain/OpenAi/ChatGptResponseDto.cs
+++ b/src/Playground.Application/Shared/Domain/OpenAi/ChatGptResponseDto.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Playground.Application.Shared.Domain.OpenAi
+{
+    public class ChatGptResponseDto
+    {
+        [JsonPropertyName("choices")]
+        public List<ChatGptChoiceDto> Choices { get; set; } = new();
+    }
+
+    public class ChatGptChoiceDto
+    {
+        [JsonPropertyName("message")]
+        public ChatGptMessageDto Message { get; set; } = new();
+    }
+}

--- a/src/Playground.Application/Shared/ExternalServices/Interfaces/IOpenAiApi.cs
+++ b/src/Playground.Application/Shared/ExternalServices/Interfaces/IOpenAiApi.cs
@@ -1,0 +1,9 @@
+using Playground.Application.Shared.Domain.OpenAi;
+
+namespace Playground.Application.Shared.ExternalServices.Interfaces
+{
+    public interface IOpenAiApi
+    {
+        Task<ChatGptResponseDto> SendPromptAsync(ChatGptRequestDto request, CancellationToken cancellationToken);
+    }
+}

--- a/src/Playground.Application/Shared/ExternalServices/OpenAiApi.cs
+++ b/src/Playground.Application/Shared/ExternalServices/OpenAiApi.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Playground.Application.Infrastructure.Configuration;
+using Playground.Application.Shared.AsyncLocals;
+using Playground.Application.Shared.Domain.OpenAi;
+using Playground.Application.Shared.ExternalServices.Interfaces;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Playground.Application.Shared.ExternalServices
+{
+    internal class OpenAiApi : IOpenAiApi
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<OpenAiApi> _logger;
+        private readonly ExternalApiOptions _options;
+
+        public OpenAiApi(ILogger<OpenAiApi> logger, ExternalApiOptions options)
+        {
+            _logger = logger;
+            _options = options;
+
+            _httpClient = new HttpClient { BaseAddress = new Uri(options.OpenIaApi.Url) };
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.OpenIaApi.ApiKey);
+            _httpClient.DefaultRequestHeaders.Add("CorrelationId", CorrelationContext.GetCorrelationId().ToString());
+        }
+
+        public async Task<ChatGptResponseDto> SendPromptAsync(ChatGptRequestDto request, CancellationToken cancellationToken)
+        {
+            var json = JsonSerializer.Serialize(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync("/chat/completions", content, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<ChatGptResponseDto>(responseJson) ?? new ChatGptResponseDto();
+        }
+    }
+}

--- a/src/Playground.Application/Shared/ExternalServices/PokemonApi.cs
+++ b/src/Playground.Application/Shared/ExternalServices/PokemonApi.cs
@@ -29,16 +29,16 @@ namespace Playground.Application.Shared.ExternalServices
             _memoryCache = memoryCache;
             _externalApiOptions = externalApiOptions;
 
-            var httpClient = new HttpClient { BaseAddress = new Uri(externalApiOptions.PokemonApiUrl) }; //TODO: Otimizar
+            var httpClient = new HttpClient { BaseAddress = new Uri(externalApiOptions.PokemonApi.Url) }; //TODO: Otimizar
             httpClient.DefaultRequestHeaders.Add("CorrelationId", CorrelationContext.GetCorrelationId().ToString());
             _pokemonApi = RestService.For<IPokemonApi>(httpClient);
 
             var retryPolicy = Policy
                 .Handle<ApiException>(exception => exception.StatusCode is HttpStatusCode.NoContent)
-                .WaitAndRetryAsync(externalApiOptions.PokemonApiRetryCount, retryAttempt 
-                    => TimeSpan.FromSeconds(externalApiOptions.PokemonApiSleepDuration * retryAttempt));
+                .WaitAndRetryAsync(externalApiOptions.PokemonApi.RetryCount, retryAttempt
+                    => TimeSpan.FromSeconds(externalApiOptions.PokemonApi.SleepDuration * retryAttempt));
 
-            var timeoutPolicy = Policy.TimeoutAsync(externalApiOptions.PokemonApiTimeout, TimeoutStrategy.Pessimistic);
+            var timeoutPolicy = Policy.TimeoutAsync(externalApiOptions.PokemonApi.Timeout, TimeoutStrategy.Pessimistic);
 
             _policyWrap = Policy.WrapAsync(retryPolicy, timeoutPolicy);
         }
@@ -77,7 +77,7 @@ namespace Playground.Application.Shared.ExternalServices
                 }
                 finally
                 {
-                    _logger.LogTroubleshooting($"[Troubleshooting][PokemonApi][GetByNameAsync] url:{_externalApiOptions.PokemonApiUrl}");
+                    _logger.LogTroubleshooting($"[Troubleshooting][PokemonApi][GetByNameAsync] url:{_externalApiOptions.PokemonApi.Url}");
                     _logger.LogTroubleshooting($"[Troubleshooting][PokemonApi][GetByNameAsync] apiResult:{apiResult.ToTroubleshooting()}");
 
                     entry.SetAbsoluteExpiration(attemptResult != null ? TimeSpan.FromSeconds(3) : TimeSpan.FromSeconds(1)); //TODO: Extract to configJson

--- a/src/Playground.Tests/Api/Controller/OpenIaIntegrationController/SendPromptOpenIaControllerTest.cs
+++ b/src/Playground.Tests/Api/Controller/OpenIaIntegrationController/SendPromptOpenIaControllerTest.cs
@@ -1,0 +1,56 @@
+using Moq;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Playground.API.Controllers;
+using Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace Playground.Tests.Controllers
+{
+    public class SendPromptOpenIaControllerTest
+    {
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger<OpenIaIntegrationController>> _mockLogger;
+        private readonly OpenIaIntegrationController _controller;
+        private readonly SendPromptCommand _validInput;
+        private readonly SendPromptCommand _invalidInput;
+        private readonly SendPromptOutput _validOutput;
+
+        public SendPromptOpenIaControllerTest()
+        {
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger<OpenIaIntegrationController>>();
+            _controller = new OpenIaIntegrationController(_mockMediator.Object, _mockLogger.Object);
+
+            _validInput = new SendPromptCommand { Prompt = "hi", Model = "gpt-3.5-turbo", Temperature = 0.7f };
+            _invalidInput = new SendPromptCommand { Prompt = string.Empty, Model = "gpt-3.5-turbo", Temperature = 0.7f };
+            _validOutput = new SendPromptOutput { Response = "hello" };
+        }
+
+        [Fact(DisplayName = "SendPromptAsync QuandoEntradaEValida DeveRetornarOk")]
+        public async Task SendPromptAsync_QuandoEntradaEValida_DeveRetornarOk()
+        {
+            _mockMediator
+                .Setup(mediator => mediator.Send(_validInput, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_validOutput);
+
+            var actionResult = await _controller.SendPromptAsync(_validInput, CancellationToken.None);
+
+            var response = Assert.IsType<OkObjectResult>(actionResult);
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(_validOutput, response.Value);
+            _mockMediator.Verify(m => m.Send(_validInput, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact(DisplayName = "SendPromptAsync QuandoEntradaEInvalida DeveRetornarBadRequest")]
+        public async Task SendPromptAsync_QuandoEntradaEInvalida_DeveRetornarBadRequest()
+        {
+            var actionResult = await _controller.SendPromptAsync(_invalidInput, CancellationToken.None);
+
+            var response = Assert.IsType<BadRequestObjectResult>(actionResult);
+            Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+            _mockMediator.Verify(m => m.Send(It.IsAny<SendPromptCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}

--- a/src/Playground.Tests/Application/Features/OpenIaIntegration/UseCase/SendPromptUseCaseHandlerTest.cs
+++ b/src/Playground.Tests/Application/Features/OpenIaIntegration/UseCase/SendPromptUseCaseHandlerTest.cs
@@ -1,0 +1,45 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.UseCase;
+using Playground.Application.Features.OpenIaIntegration.Command.SendPrompt.Models;
+using Playground.Application.Shared.ExternalServices.Interfaces;
+using Playground.Application.Shared.Domain.OpenAi;
+
+namespace Playground.Tests.Controllers
+{
+    public class SendPromptUseCaseHandlerTest
+    {
+        private readonly Mock<IOpenAiApi> _mockOpenAiApi;
+        private readonly Mock<ILogger<SendPromptUseCaseHandler>> _mockLogger;
+        private readonly SendPromptUseCaseHandler _handler;
+
+        public SendPromptUseCaseHandlerTest()
+        {
+            _mockOpenAiApi = new Mock<IOpenAiApi>();
+            _mockLogger = new Mock<ILogger<SendPromptUseCaseHandler>>();
+            _handler = new SendPromptUseCaseHandler(_mockOpenAiApi.Object, _mockLogger.Object);
+        }
+
+        [Fact(DisplayName = "Handle QuandoExecutado DeveRetornarResposta")]
+        public async Task Handle_QuandoExecutado_DeveRetornarResposta()
+        {
+            var command = new SendPromptCommand { Prompt = "hi", Model = "gpt-3.5-turbo", Temperature = 0.7f };
+            var apiResponse = new ChatGptResponseDto
+            {
+                Choices = new List<ChatGptChoiceDto>
+                {
+                    new ChatGptChoiceDto { Message = new ChatGptMessageDto { Content = "hello" } }
+                }
+            };
+
+            _mockOpenAiApi
+                .Setup(api => api.SendPromptAsync(It.IsAny<ChatGptRequestDto>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(apiResponse);
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.Equal("hello", result.Response);
+            _mockOpenAiApi.Verify(api => api.SendPromptAsync(It.IsAny<ChatGptRequestDto>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -133,3 +133,12 @@ To learn more about filtering use `--help`.
 ```
 Alterando somente a classe GetByIdToDoItemUseCaseHandler, melhore sua performance. Antes de fazer commit, sempre rode o teste de performance e exiba os resultados
 ```
+## Pedido 21
+```
+Crie u a nova feature, para integrar com o chatGPT, vou enviar minhas chaves de acesso nem outro prompt. A feature deve chamar OpenIaIntegrationFeature. Crie a Controller mo as respectivas actions. A conexão com o ChatGPT deve estar na camada equivalente de consumo de APis. O Objetivo é enviar um prompt e receber a resposta em texto. Quero ter a opção de controlar temperatura, modelo da LLM, e etc.
+```
+## Pedido 22
+```
+Para a chave ’ExternalApiOptions’, crie um conjunto pata o PokemonApi e outro para o OpenIaApi.
+Ajuste os padrões da feature e controller da OpenIA, usando a documentação
+```


### PR DESCRIPTION
## Summary
- split ExternalApiOptions into nested options for PokemonApi and OpenIaApi
- rename OpenIA feature namespace to OpenIaIntegration
- update controller and services to new configuration
- adjust tests and configuration
- log new user request

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln`


------
https://chatgpt.com/codex/tasks/task_e_68561dfea0d4832c919010e43c4feccf