### PR TITLE
Fix GraphQL variable escaping in add-pr script

### DIFF
--- a/scripts/add-pr-to-project.sh
+++ b/scripts/add-pr-to-project.sh
@@ -20,10 +20,10 @@ PR_NODE_ID=$(jq -r '.pull_request.node_id' "$EVENT_PATH")
 
 PROJECT_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
   -X POST -H "Content-Type: application/json" \
-  -d "{\"query\":\"query($owner:String!,$number:Int!){ $OWNER_FIELD(login:$owner){ projectV2(number:$number){ id } } }\",\"variables\":{\"owner\":\"$OWNER_NAME\",\"number\":$PROJECT_NUMBER}}" https://api.github.com/graphql | jq -r ".data.$OWNER_FIELD.projectV2.id")
+  -d "{\"query\":\"query(\$owner:String!,\$number:Int!){ $OWNER_FIELD(login:\$owner){ projectV2(number:\$number){ id } } }\",\"variables\":{\"owner\":\"$OWNER_NAME\",\"number\":$PROJECT_NUMBER}}" https://api.github.com/graphql | jq -r ".data.$OWNER_FIELD.projectV2.id")
 
 curl -s -H "Authorization: Bearer $TOKEN" \
   -X POST -H "Content-Type: application/json" \
-  -d "{\"query\":\"mutation($project:ID!,$content:ID!){ addProjectV2ItemById(input:{projectId:$project, contentId:$content}){item{id}} }\",\"variables\":{\"project\":\"$PROJECT_ID\",\"content\":\"$PR_NODE_ID\"}}" https://api.github.com/graphql > /dev/null
+  -d "{\"query\":\"mutation(\$project:ID!,\$content:ID!){ addProjectV2ItemById(input:{projectId:\$project, contentId:\$content}){item{id}} }\",\"variables\":{\"project\":\"$PROJECT_ID\",\"content\":\"$PR_NODE_ID\"}}" https://api.github.com/graphql > /dev/null
 
 echo "Pull request added to project"

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -181,3 +181,21 @@ Adicione testes para todos os status code
 ```
 Envie correlationId em todas as requisições
 ```
+
+## Pedido 29
+```
+A Action Vincular Pull Requests ao Projeto, esta dando o seguinte erro:
+
+Run ./scripts/add-pr-to-project.sh https://github.com/users/AlbertKellner/projects/2
+  ./scripts/add-pr-to-project.sh https://github.com/users/AlbertKellner/projects/2
+  shell: /usr/bin/bash -e {0}
+  env:
+    GITHUB_TOKEN: ***
+./scripts/add-pr-to-project.sh: line 23: owner: unbound variable
+Error: Process completed with exit code 1.
+
+O que pode ser? Faça uma análise completa
+Responsável em português
+
+Pode corrigir
+```


### PR DESCRIPTION
## Summary
- escape dollar signs in GraphQL queries so shell doesn't try to expand `$owner`, `$number`, etc.
- log new user request in `wiki/Pedidos.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856cefd9d48832c99643febfabee11e