### PR TITLE
Add log check to ToDoItem integration tests

### DIFF
--- a/src/IntegrationTests/Api/ToDoItemControllerIntegrationTest.cs
+++ b/src/IntegrationTests/Api/ToDoItemControllerIntegrationTest.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Playground.IntegrationTests;
@@ -12,6 +13,23 @@ namespace Playground.IntegrationTests;
 public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly HttpClient _client;
+
+    private static async Task<(HttpResponseMessage Response, string Logs)>
+        SendAsync(HttpClient client, HttpRequestMessage request)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            var response = await client.SendAsync(request);
+            return (response, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
 
     public ToDoItemControllerIntegrationTest(WebApplicationFactory<Program> factory)
     {
@@ -23,7 +41,7 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/99");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
-        var response = await _client.SendAsync(request);
+        var (response, logs) = await SendAsync(_client, request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var result = await response.Content.ReadFromJsonAsync<GetByIdToDoItemOutput>();
@@ -31,6 +49,8 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
         Assert.Equal(99, result!.Id);
         Assert.Equal("GetById - ToDoItem - UseCaseHandler", result.Task);
         Assert.True(result.IsCompleted);
+
+        Assert.DoesNotContain("[ERR]", logs);
     }
 
     [Fact(DisplayName = "GetByIdAsync QuandoIdNaoExiste DeveRetornarNoContent")]
@@ -38,9 +58,10 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/100");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
-        var response = await _client.SendAsync(request);
+        var (response, logs) = await SendAsync(_client, request);
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.DoesNotContain("[ERR]", logs);
     }
 
     [Fact(DisplayName = "GetByIdAsync QuandoIdInvalido DeveRetornarBadRequest")]
@@ -48,12 +69,13 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/0");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
-        var response = await _client.SendAsync(request);
+        var (response, logs) = await SendAsync(_client, request);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
         var errors = await response.Content.ReadFromJsonAsync<string[]>();
         Assert.NotNull(errors);
         Assert.Contains("Id precisa ser maior que zero", errors!);
+        Assert.DoesNotContain("[ERR]", logs);
     }
 }

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -218,3 +218,9 @@ Tire o Skip delas
 ```
 Os testes estao quebrando
 ```
+
+## Pedido 34
+```
+No teste integrado que não é no mockado, classe ToDoItemControllerIntegrationTest, verifique se não aparece nenhum erro no log
+```
+


### PR DESCRIPTION
## Summary
- capture console logs in `ToDoItemControllerIntegrationTest`
- ensure no `[ERR]` entries appear during each test
- record new user request

## Testing
- `dotnet build src/Playground.Ecs.sln` *(fails: dotnet not found)*
- `dotnet test src/Playground.Ecs.sln` *(fails: dotnet not found)*
- `dotnet test src/IntegrationTests/IntegrationTests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daf4e2b6c832ca97519e3af76c46b