### PR TITLE
Record logs to file in integration tests

### DIFF
--- a/src/IntegrationTests/Api/ToDoItemControllerIntegrationTest.cs
+++ b/src/IntegrationTests/Api/ToDoItemControllerIntegrationTest.cs
@@ -31,6 +31,12 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
         }
     }
 
+    private static void SaveLogs(string logs, string methodName)
+    {
+        var filePath = Path.Combine(AppContext.BaseDirectory, $"{methodName}ExecutionLogs");
+        File.WriteAllText(filePath, logs);
+    }
+
     public ToDoItemControllerIntegrationTest(WebApplicationFactory<Program> factory)
     {
         _client = factory.CreateClient();
@@ -42,6 +48,7 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/99");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
         var (response, logs) = await SendAsync(_client, request);
+        SaveLogs(logs, nameof(GetByIdAsync_QuandoIdExiste_DeveRetornarItem));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var result = await response.Content.ReadFromJsonAsync<GetByIdToDoItemOutput>();
@@ -59,6 +66,7 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/100");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
         var (response, logs) = await SendAsync(_client, request);
+        SaveLogs(logs, nameof(GetByIdAsync_QuandoIdNaoExiste_DeveRetornarNoContent));
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         Assert.DoesNotContain("[ERR]", logs);
@@ -70,6 +78,7 @@ public class ToDoItemControllerIntegrationTest : IClassFixture<WebApplicationFac
         using var request = new HttpRequestMessage(HttpMethod.Get, "/todo/0");
         request.Headers.Add("CorrelationId", Guid.NewGuid().ToString());
         var (response, logs) = await SendAsync(_client, request);
+        SaveLogs(logs, nameof(GetByIdAsync_QuandoIdInvalido_DeveRetornarBadRequest));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 

--- a/wiki/Pedidos.md
+++ b/wiki/Pedidos.md
@@ -224,3 +224,8 @@ Os testes estao quebrando
 No teste integrado que não é no mockado, classe ToDoItemControllerIntegrationTest, verifique se não aparece nenhum erro no log
 ```
 
+## Pedido 35
+```
+No teste integrado da classe ToDoItemControllerIntegrationTest, grave a saída dos logs em um arquivo com o nome do método de teste seguido por a palavra ExecutionLogs
+```
+


### PR DESCRIPTION
## Summary
- record execution logs in `ToDoItemControllerIntegrationTest` test methods
- log request in wiki/Pedidos

## Testing
- `dotnet build src/Playground.Ecs.sln`
- `dotnet test src/Playground.Ecs.sln --no-build`
- `dotnet test src/IntegrationTests/IntegrationTests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685e32593fa8832ca6dbc1522c07f809